### PR TITLE
Added support for multiple alternate alleles and eased construction of genotypes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ BIN_SOURCES = vcfecho.cpp \
 			  vcfaltcount.cpp \
 			  vcfhetcount.cpp \
 			  vcfstats.cpp \
-			  vcffilter.cpp
+			  vcffilter.cpp \
+			  vcfgenotypes.cpp
 BINS = $(BIN_SOURCES:.cpp=)
 
 all: $(OBJECTS) $(BINS)

--- a/Variant.cpp
+++ b/Variant.cpp
@@ -7,6 +7,8 @@ void Variant::parse(string& line) {
     // clean up potentially variable data structures
     info.clear();
     format.clear();
+    alt.clear();
+    alleles.clear();
 
     // #CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO    FORMAT [SAMPLE1 .. SAMPLEN]
     vector<string> fields = split(line, '\t');

--- a/Variant.cpp
+++ b/Variant.cpp
@@ -243,16 +243,29 @@ void Variant::addFilter(string& tag) {
         filter += "," + tag;
 }
 
+void Variant::printAlt(ostream& out) {
+    for (vector<string>::iterator i = alt.begin(); i != alt.end(); ++i) {
+        out << *i;
+        // add a comma for all but the last alternate allele
+        if (i != (alt.end() - 1)) out << ",";
+    }
+}
+
+void Variant::printAlleles(ostream& out) {
+    for (vector<string>::iterator i = alleles.begin(); i != alleles.end(); ++i) {
+        out << *i;
+        // add a comma for all but the last alternate allele
+        if (i != (alleles.end() - 1)) out << ",";
+    }
+}
+
 ostream& operator<<(ostream& out, Variant& var) {
     out << var.sequenceName << "\t"
         << var.position << "\t"
         << var.id << "\t"
         << var.ref << "\t";
-    for (vector<string>::iterator i = var.alt.begin(); i != var.alt.end(); ++i) {
-        out << *i;
-        // add a comma for all but the last alternate allele
-        if (i != (var.alt.end() - 1)) out << ",";
-    }
+    // report the list of alterbate alleles.
+    var.printAlt(out);
     out << "\t"
         << var.quality << "\t"
         << var.filter << "\t";

--- a/Variant.cpp
+++ b/Variant.cpp
@@ -15,7 +15,14 @@ void Variant::parse(string& line) {
     position = strtoll(fields.at(1).c_str(), &end, 10);
     id = fields.at(2);
     ref = fields.at(3);
-    alt = fields.at(4); // TODO handle multi-allelic situations
+    alt = split(fields.at(4), ","); // a comma-separated list of alternate alleles
+
+    // make a list of all (ref + alts) alleles, allele[0] = ref, alleles[1:] = alts
+    // add the ref allele ([0]), resize for the alt alleles, and then add the alt alleles
+    alleles.push_back(ref);
+    alleles.resize(alt.size()+1);
+    std::copy(alt.begin(), alt.end(), alleles.begin()+1);
+
     quality = atoi(fields.at(5).c_str());
     filter = fields.at(6);
     vector<string> infofields = split(fields.at(7), ';');
@@ -240,8 +247,13 @@ ostream& operator<<(ostream& out, Variant& var) {
     out << var.sequenceName << "\t"
         << var.position << "\t"
         << var.id << "\t"
-        << var.ref << "\t"
-        << var.alt << "\t"
+        << var.ref << "\t";
+    for (vector<string>::iterator i = var.alt.begin(); i != var.alt.end(); ++i) {
+        out << *i;
+        // add a comma for all but the last alternate allele
+        if (i != (var.alt.end() - 1)) out << ",";
+    }
+    out << "\t"
         << var.quality << "\t"
         << var.filter << "\t";
     for (map<string, string>::iterator i = var.info.begin(); i != var.info.end(); ++i) {

--- a/Variant.h
+++ b/Variant.h
@@ -125,6 +125,9 @@ public:
     bool getInfoValueBool(string& key);
     float getInfoValueFloat(string& key);
     string getInfoValueString(string& key);
+    void printAlt(ostream& out);      // print a comma-sep list of alternate alleles to an ostream
+    void printAlleles(ostream& out);  // print a comma-sep list of *all* alleles to an ostream
+     
 
 private:
     string lastFormat;

--- a/Variant.h
+++ b/Variant.h
@@ -94,7 +94,11 @@ public:
     unsigned long position;
     string id;
     string ref;
-    string alt;
+    vector<string> alt;      // a list of all the alternate alleles present at this locus
+    vector<string> alleles;  // a list all alleles (ref + alt) at this locus
+                             // the indicies are organized such that the genotype codes (0,1,2,.etc.)
+                             // correspond to the correct offest into the allelese vector.
+                             // that is, alleles[0] = ref, alleles[1] = first alternate allele, etc.
     string filter;
     int quality;
     map<string, string> info;

--- a/sample.vcf
+++ b/sample.vcf
@@ -1,0 +1,31 @@
+##fileformat=VCFv4.0
+##fileDate=20090805
+##source=myImputationProgramV3.1
+##reference=1000GenomesPilot-NCBI36
+##phasing=partial
+##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of Samples With Data">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=AC,Number=.,Type=Integer,Description="Allele count in genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">
+##INFO=<ID=AF,Number=.,Type=Float,Description="Allele Frequency">
+##INFO=<ID=AA,Number=1,Type=String,Description="Ancestral Allele">
+##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP membership, build 129">
+##INFO=<ID=H2,Number=0,Type=Flag,Description="HapMap2 membership">
+##FILTER=<ID=q10,Description="Quality below 10">
+##FILTER=<ID=s50,Description="Less than 50% of samples have data">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth">
+##FORMAT=<ID=HQ,Number=2,Type=Integer,Description="Haplotype Quality">
+##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
+##ALT=<ID=CNV,Description="Copy number variable region">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA00001	NA00002	NA00003
+19	111	.	A	C	9.6	.	.	GT:HQ	0|0:10,10	0|0:10,10	0/1:3,3
+19	112	.	A	G	10	.	.	GT:HQ	0|0:10,10	0|0:10,10	0/1:3,3
+20	14370	rs6054257	G	A	29	PASS	NS=3;DP=14;AF=0.5;DB;H2	GT:GQ:DP:HQ	0|0:48:1:51,51	1|0:48:8:51,51	1/1:43:5:.,.
+20	17330	.	T	A	3	q10	NS=3;DP=11;AF=0.017	GT:GQ:DP:HQ	0|0:49:3:58,50	0|1:3:5:65,3	0/0:41:3:.,.
+20	1110696	rs6040355	A	G,T	67	PASS	NS=2;DP=10;AF=0.333,0.667;AA=T;DB	GT:GQ:DP:HQ	1|2:21:6:23,27	2|1:2:0:18,2	2/2:35:4:.,.
+20	1230237	.	T	.	47	PASS	NS=3;DP=13;AA=T	GT:GQ:DP:HQ	0|0:54:.:56,60	0|0:48:4:51,51	0/0:61:2:.,.
+20	1234567	microsat1	G	GA,GAC	50	PASS	NS=3;DP=9;AA=G;AN=6;AC=3,1	GT:GQ:DP	0/1:.:4	0/2:17:2	1/1:40:3
+20	1235237	.	T	.	.	.	.	GT	0/0	0|0	./.
+X	10	rsTest	AC	A,ATG	10	PASS	.	GT	0	0/1	0|2

--- a/vcfgenotypes.cpp
+++ b/vcfgenotypes.cpp
@@ -1,0 +1,45 @@
+#include "Variant.h"
+#include "split.h"
+#include <string>
+#include <iostream>
+
+using namespace std;
+using namespace vcf;
+
+
+int main(int argc, char** argv) {
+
+    if (argc != 2) {
+        cerr << "usage: " << argv[0] << " <vcf file>" << endl
+             << "report the genotypes for each sample, for each variant in the vcf file" << endl;
+        return 1;
+    }
+
+    string filename = argv[1];
+
+    VariantCallFile variantFile(filename);
+    if (!variantFile.is_open()) {
+        return 1;
+    }
+
+    Variant var(variantFile);
+    while (variantFile.getNextVariant(var)) {
+        map<string, map<string, string> >::iterator s     = var.samples.begin(); 
+        map<string, map<string, string> >::iterator sEnd  = var.samples.end();
+        for (; s != sEnd; ++s) {
+            map<string, string>& sample = s->second;
+            string& genotype = sample["GT"];
+            vector<string> gt = split(genotype, "|/");
+            cout << s->first << ":";
+            for (vector<string>::iterator g = gt.begin(); g != gt.end(); ++g) {
+                int index = atoi(g->c_str());
+                cout << var.alleles[index] << ",";
+            }
+            cout << "\t";
+        }
+        cout << "\t" << endl;
+    }
+    return 0;
+
+}
+

--- a/vcfgenotypes.cpp
+++ b/vcfgenotypes.cpp
@@ -26,18 +26,28 @@ int main(int argc, char** argv) {
     while (variantFile.getNextVariant(var)) {
         map<string, map<string, string> >::iterator s     = var.samples.begin(); 
         map<string, map<string, string> >::iterator sEnd  = var.samples.end();
+        
+        cout << var.sequenceName << "\t"
+             << var.position     << "\t"
+             << var.ref          << "\t";
+        var.printAlt(cout);     cout << "\t"; 
+        var.printAlleles(cout); cout << "\t"; 
+        
         for (; s != sEnd; ++s) {
             map<string, string>& sample = s->second;
             string& genotype = sample["GT"];
             vector<string> gt = split(genotype, "|/");
+            
+            // report the sample and it's genotype
             cout << s->first << ":";
             for (vector<string>::iterator g = gt.begin(); g != gt.end(); ++g) {
                 int index = atoi(g->c_str());
-                cout << var.alleles[index] << ",";
+                cout << var.alleles[index];
+                if (g != (gt.end()-1)) cout << "/";
             }
             cout << "\t";
         }
-        cout << "\t" << endl;
+        cout << endl;
     }
     return 0;
 


### PR DESCRIPTION
Hi Erik,
   I've been working on some tools for VCF files that I need in my research.  I ended up forking vcflib and added support for multiple alternate alleles (i.e., Variant.alt is now a vector).  I also created a new attribute called "alleles", which is a vector of _all_ the alleles, where the REF allele is bucket 0.  This allows one to quickly construct genotypes by using the integer values in genotype strings as pointers into the alleles vector (e.g., "0/1" would grab the REF allele and the first ALT allele).

I've updated the overload of "<<" to accomodate the alt vector and added two convenience methods (printAlt() and printAlleles).  Lastly, I've added a new example script called vcfgenotypes.cppp, which illustrates the new functionality on a sample file I've added called sample.vcf

Let me know what you think.
