### PR TITLE
Fix finding overlaps with bed files

### DIFF
--- a/src/BedReader.h
+++ b/src/BedReader.h
@@ -110,7 +110,7 @@ public:
         targets = entries();
         map<string, vector<Interval<BedTarget*> > > intervalsBySeq;
         for (vector<BedTarget>::iterator t = targets.begin(); t != targets.end(); ++t) {
-            intervalsBySeq[t->seq].push_back(Interval<BedTarget*>(t->left, t->right, &*t));
+            intervalsBySeq[t->seq].push_back(Interval<BedTarget*>(1 + t->left, t->right, &*t));
         }
         for (map<string, vector<Interval<BedTarget*> > >::iterator s = intervalsBySeq.begin(); s != intervalsBySeq.end(); ++s) {
             intervals[s->first] = IntervalTree<BedTarget*>(s->second);

--- a/src/vcfannotate.cpp
+++ b/src/vcfannotate.cpp
@@ -107,7 +107,7 @@ int main(int argc, char** argv) {
 
     Variant var(variantFile);
     while (variantFile.getNextVariant(var)) {
-        BedTarget record(var.sequenceName, var.position, var.position + var.ref.size(), "");
+        BedTarget record(var.sequenceName, var.position, var.position + var.ref.size() - 1, "");
         vector<BedTarget*> overlaps = bed.targetsOverlapping(record);
         vector<string> annotations;
         if (!overlaps.empty()) {

--- a/src/vcfintersect.cpp
+++ b/src/vcfintersect.cpp
@@ -309,7 +309,7 @@ int main(int argc, char** argv) {
         }
 
         if (usingBED) {
-            BedTarget record(var.sequenceName, var.position, var.position + var.ref.size(), "");
+            BedTarget record(var.sequenceName, var.position, var.position + var.ref.size() - 1, "");
             vector<BedTarget*> overlaps = bed.targetsOverlapping(record);
 
             if (!invert && !overlaps.empty()) {


### PR DESCRIPTION
I've noticed that sometimes vcfannotate with would annotate some SNPs twice

given a bed file:
chr1 5 6 value1
chr1 6 7 value 2

vcf file:
CHROM POS
chr1 6

with vcfannotate
That row should be annotated once with "value 1"
but instead it would be annotated twice with "value1:value2"

I've emailed you some sample input.

This fix changes the internal representation of the bed interval from 4 5 to 5 5 in the case of a snp
and it changes the target for targetsOverlapping from 5 6 to 5 5 in the case of a snp

Cheers,
