### PR TITLE
Complementary fix for glia regional realignment around variants

### DIFF
--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -1249,7 +1249,7 @@ bool VariantCallFile::setRegion(string seq, long int start, long int end) {
     } else {
         regionstr << seq << ":" << start;
     }
-    setRegion(regionstr.str());
+    return setRegion(regionstr.str());
 }
 
 bool VariantCallFile::setRegion(string region) {


### PR DESCRIPTION
Ensures a success value returned from setRegion on tabix file when called with separate contig/start/end. Otherwise setRegion always reports 0 and is treated as failing when called via glia.
