### PR TITLE
vcfcreatemulti: Avoid segfault when passed VCF file with no variants

### DIFF
--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -1249,7 +1249,7 @@ bool VariantCallFile::setRegion(string seq, long int start, long int end) {
     } else {
         regionstr << seq << ":" << start;
     }
-    return setRegion(regionstr.str());
+    setRegion(regionstr.str());
 }
 
 bool VariantCallFile::setRegion(string region) {

--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -1249,7 +1249,7 @@ bool VariantCallFile::setRegion(string seq, long int start, long int end) {
     } else {
         regionstr << seq << ":" << start;
     }
-    setRegion(regionstr.str());
+    return setRegion(regionstr.str());
 }
 
 bool VariantCallFile::setRegion(string region) {

--- a/src/vcfcreatemulti.cpp
+++ b/src/vcfcreatemulti.cpp
@@ -186,8 +186,10 @@ int main(int argc, char** argv) {
 
     }
 
-    Variant result = createMultiallelic(vars);
-    cout << result << endl;
+    if (!vars.empty()) {
+        Variant result = createMultiallelic(vars);
+        cout << result << endl;
+    }
 
     return 0;
 


### PR DESCRIPTION
Erik;
vcfcreatemulti will currently segfault when passed a VCF file with no variants. I ran into this case when merging files in smaller regions where some had no variants. This small fix correctly outputs an equivalent empty file.

Apologies, my vcflib history is a bit wacky because I have another outstanding pull request. Feel free to manually apply or cherry pick the relevant commit (https://github.com/chapmanb/vcflib/commit/c6fe008a2ac04540ddffb766c13d84aaa08013de).
