### PR TITLE
Fixed bug with vcfallelicprimitives handling of monomorphic reference mn...

### DIFF
--- a/samples/sample.vcf
+++ b/samples/sample.vcf
@@ -29,3 +29,4 @@
 20	1234567	microsat1	G	GA,GAC	50	PASS	NS=3;DP=9;AA=G;AN=6;AC=3,1	GT:GQ:DP	0/1:.:4	0/2:17:2	1/1:40:3
 20	1235237	.	T	.	.	.	.	GT	0/0	0|0	./.
 X	10	rsTest	AC	A,ATG	10	PASS	.	GT	0	0/1	0|2
+X	40	monomorphic_ref_mnp	GGG	.	 100	PASS	.	GT	0/0	0|0	./.

--- a/src/vcfallelicprimitives.cpp
+++ b/src/vcfallelicprimitives.cpp
@@ -134,6 +134,11 @@ int main(int argc, char** argv) {
             continue;
         }
 
+        if (var.alt[0] == ".") { // if monomorphic reference
+            cout << var << endl;
+            continue;
+        }
+
         // collect variant allele indexed membership
         map<string, vector<int> > variantAlleleIndexes; // from serialized VariantAllele to indexes
         for (map<string, vector<VariantAllele> >::iterator a = varAlleles.begin(); a != varAlleles.end(); ++a) {


### PR DESCRIPTION
...ps which are produced by some snp callers

e.g.

X       40      .       GGG    .    100  PASS      LEN=1,2;TYPE=snp,complex GT      0|0     0|0     .

was being translated to this. Note the invalid alternate allele field.

X       40      .       GGG    .GG,.    100  PASS      LEN=1,2;TYPE=snp,complex GT      0|0     0|0     .
