### PR TITLE
switched git:// to https:// to avoid problems with firewall rules.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,21 +1,21 @@
 [submodule "tabixpp"]
 	path = tabixpp
-	url = git://github.com/ekg/tabixpp.git
+	url = https://github.com/ekg/tabixpp.git
 [submodule "smithwaterman"]
 	path = smithwaterman
-	url = git://github.com/ekg/smithwaterman.git
+	url = https://github.com/ekg/smithwaterman.git
 [submodule "multichoose"]
 	path = multichoose
-	url = git://github.com/ekg/multichoose.git
+	url = https://github.com/ekg/multichoose.git
 [submodule "fastahack"]
 	path = fastahack
-	url = git://github.com/ekg/fastahack.git
+	url = https://github.com/ekg/fastahack.git
 [submodule "intervaltree"]
 	path = intervaltree
-	url = git://github.com/ekg/intervaltree.git
+	url = https://github.com/ekg/intervaltree.git
 [submodule "fsom"]
 	path = fsom
-	url = git://github.com/ekg/fsom.git
+	url = https://github.com/ekg/fsom.git
 [submodule "filevercmp"]
 	path = filevercmp
 	url = https://github.com/ekg/filevercmp.git


### PR DESCRIPTION
I'm currently building on some machines that cannot access github on anything but https -- and I'm guessing I'm probably not the only person who will run into this problem.

This patch alters all calls to git://github.com (in the .gitmodules file) to use https://github.com/
