### PR TITLE
Many bugs in vcfdistance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ vcfevenregions
 vcfgenosummarize
 vcfgenosamplenames
 vcf2fasta
+/bin/

--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,9 @@ $(BINS): $(BIN_SOURCES) $(OBJECTS) $(SMITHWATERMAN) $(FASTAHACK) $(DISORDER) $(L
 libvcflib.a: $(OBJECTS) $(SMITHWATERMAN) $(FASTAHACK) $(DISORDER) $(LEFTALIGN) $(INDELALLELE) $(SSW) $(FSOM) $(FILEVERCMP)
 	ar rvs libvcflib.a $(OBJECTS) $(SMITHWATERMAN) $(FASTAHACK) $(DISORDER) $(LEFTALIGN) $(INDELALLELE) $(SSW) $(FSOM) $(FILEVERCMP)
 
+test: $(BINS)
+	@prove -Itests/lib -w tests/*.t
+
 clean:
 	rm -f $(BINS) $(OBJECTS)
 	rm -f ssw_cpp.o ssw.o
@@ -160,4 +163,4 @@ clean:
 	cd smithwaterman && make clean
 	cd fastahack && make clean
 
-.PHONY: clean all
+.PHONY: clean all test

--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -1259,7 +1259,7 @@ bool VariantCallFile::parseHeader(string& hs) {
 
 bool VariantCallFile::getNextVariant(Variant& var) {
         if (firstRecord && !justSetRegion) {
-            if (!line.empty()) {
+            if (!line.empty() && line.substr(0,1) != "#") {
                 var.parse(line, parseSamples);
                 firstRecord = false;
                 _done = false;
@@ -1269,7 +1269,7 @@ bool VariantCallFile::getNextVariant(Variant& var) {
             }
         }
         if (usingTabix) {
-            if (justSetRegion && !line.empty()) {
+            if (justSetRegion && !line.empty() && line.substr(0,1) != "#") {
                 if (firstRecord) {
                     firstRecord = false;
                 }

--- a/src/vcfdistance.cpp
+++ b/src/vcfdistance.cpp
@@ -10,7 +10,7 @@ int main(int argc, char** argv) {
 
     if (argc > 1) {
         cerr << "usage: " << argv[0] << " <[vcf file]" << endl
-             << "adds a tag (BasesToNextVariant) to each variant record which indicates" << endl
+             << "adds a tag (BasesToClosestVariant) to each variant record which indicates" << endl
              << "the distance to the nearest variant" << endl;
         return 1;
     }

--- a/src/vcfdistance.cpp
+++ b/src/vcfdistance.cpp
@@ -42,41 +42,48 @@ int main(int argc, char** argv) {
 
     cout << variantFile.header << endl;
 
-    // get the first distances
-    if (vars.at(0)->sequenceName == vars.at(1)->sequenceName) {
-        vars.at(0)->info[tag].push_back(convert(vars.at(1)->position - vars.at(0)->position));
-    }
+    if (!vars.at(0)->sequenceName.empty()) {
+        if (!vars.at(1)->sequenceName.empty()) {
+            // at least two variants, so calculate the first distance
+            if (vars.at(0)->sequenceName == vars.at(1)->sequenceName) {
+                vars.at(0)->info[tag].push_back(convert(vars.at(1)->position - vars.at(0)->position));
+            }
+            cout << *vars.at(0) << endl;
 
-    while (variantFile.getNextVariant(*vars.back())) {
+            if (!vars.at(2)->sequenceName.empty()) {
+                // at least three variants, so starting with the first three,
+                // calculate the middle variant's closest distance, and then
+                // slide the window forward one.
+                do {
+                    if (vars.at(1)->sequenceName == vars.at(0)->sequenceName &&
+                        vars.at(1)->sequenceName == vars.at(2)->sequenceName) {
+                        vars.at(1)->info[tag].push_back(convert(min(vars.at(1)->position - vars.at(0)->position,
+                                                                    vars.at(2)->position - vars.at(1)->position)));
+                    } else if (vars.at(1)->sequenceName == vars.at(0)->sequenceName) {
+                        vars.at(1)->info[tag].push_back(convert(vars.at(1)->position - vars.at(0)->position));
+                    } else if (vars.at(2)->sequenceName == vars.at(1)->sequenceName) {
+                        vars.at(1)->info[tag].push_back(convert(vars.at(2)->position - vars.at(1)->position));
+                    } else {
+                        // don't add the tag
+                    }
+                    cout << *vars.at(1) << endl;
+                    // rotate
+                    Variant* v = vars.at(0);
+                    vars.at(0) = vars.at(1);
+                    vars.at(1) = vars.at(2);
+                    vars.at(2) = v;
+                } while (variantFile.getNextVariant(*vars.back()));
+            }
 
-        if (vars.at(1)->sequenceName == vars.at(0)->sequenceName &&
-            vars.at(1)->sequenceName == vars.at(2)->sequenceName) {
-            vars.at(1)->info[tag].push_back(convert(min(vars.at(1)->position - vars.at(0)->position,
-                                                        vars.at(2)->position - vars.at(1)->position)));
-        } else if (vars.at(1)->sequenceName == vars.at(0)->sequenceName) {
-            vars.at(1)->info[tag].push_back(convert(vars.at(1)->position - vars.at(0)->position));
-        } else if (vars.at(2)->sequenceName == vars.at(1)->sequenceName) {
-            vars.at(1)->info[tag].push_back(convert(vars.at(2)->position - vars.at(1)->position));
+            // assign the last distance and output the last variant
+            if (vars.at(0)->sequenceName == vars.at(1)->sequenceName) {
+                vars.at(1)->info[tag].push_back(convert(vars.at(1)->position - vars.at(0)->position));
+            }
+            cout << *vars.at(1) << endl;
         } else {
-            // don't add the tag
+            // output the lone variant line untouched
+            cout << *vars.at(0) << endl;
         }
-        cout << *vars.front() << endl;
-        // rotate
-        Variant* v = vars.at(0);
-        vars.at(0) = vars.at(1);
-        vars.at(1) = vars.at(2);
-        vars.at(2) = v;
-
-    }
-
-    // assign the last distances
-    
-    if (vars.at(0)->sequenceName == vars.at(1)->sequenceName) {
-        vars.at(0)->info[tag].push_back(convert(vars.at(1)->position - vars.at(0)->position));
-        cout << *vars.at(0) << endl;
-	
-        vars.at(1)->info[tag].push_back(convert(vars.at(1)->position - vars.at(0)->position));
-        cout << *vars.at(1) << endl;
     }
 
     return 0;

--- a/tests/lib/Local/vcflib/Test.pm
+++ b/tests/lib/Local/vcflib/Test.pm
@@ -1,0 +1,32 @@
+use strict;
+use warnings;
+
+package Local::vcflib::Test;
+use base 'Exporter';
+
+use File::Basename qw< dirname >;
+use IPC::Run3 qw< run3 >;
+use Test::More;
+
+our @EXPORT = qw( run run_ok );
+our $BIN    = dirname(__FILE__) . "/../../../../bin";
+
+sub run {
+    my ($run, $stdin)    = @_;
+    my ($command, @opts) = @$run;
+    run3(["$BIN/$command", @opts], \$stdin, \(my $stdout), \(my $stderr));
+    return ($stdout, $stderr, $?);
+}
+
+sub run_ok {
+    local $Test::Builder::Level = $Test::Builder::Level + 1;
+    my ($stdout, $stderr, $exit) = run(@_);
+    ok $exit >> 8 == 0, "exit code"
+        or diag "error running command: " . join(" ", @{$_[0]}) . "\n"
+               ."with input:\n$_[1]\n--\n"
+               ."exit code = " . ($exit >> 8) . " (system() return value = $exit)\n"
+               ."stderr = \n$stderr";
+    return ($stdout, $stderr);
+}
+
+1;

--- a/tests/vcfdistance.t
+++ b/tests/vcfdistance.t
@@ -21,6 +21,9 @@ my ($output, $header) = ('', <<'');
 ##INFO=<ID=BasesToClosestVariant,Number=1,Type=Integer,Description="Number of bases to the closest variant in the file.">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
 
+#
+# Various numbers of variant lines
+#
 ($output) = run_ok(["vcfdistance"], variants(5));
 is $output, $header . <<'', "distances for 5 variant lines";
 refseq	502	.	G	A	38553	PASS	BasesToClosestVariant=50;
@@ -53,5 +56,43 @@ refseq	502	.	G	A	38553	PASS
 
 ($output) = run_ok(["vcfdistance"], variants(0));
 is $output, $header, "distances for 0 variant lines";
+
+#
+# Various combinations of reference sequences (obviously non-comparable)
+#
+@vcf = split /\n/, <<'';
+##fileformat=VCFv4.0
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+ref1	502	.	G	A	38553	PASS	
+ref2	552	.	G	A	24044	PASS	
+ref2	660	.	G	A	38553	PASS	
+ref2	678	.	G	A	24044	PASS	
+ref3	684	.	G	A	24044	PASS	
+
+($output) = run_ok(["vcfdistance"], variants(5));
+is $output, $header . <<'', "distances for 5 variant lines; three references";
+ref1	502	.	G	A	38553	PASS	
+ref2	552	.	G	A	24044	PASS	BasesToClosestVariant=108;
+ref2	660	.	G	A	38553	PASS	BasesToClosestVariant=18;
+ref2	678	.	G	A	24044	PASS	BasesToClosestVariant=18;
+ref3	684	.	G	A	24044	PASS	
+
+($output) = run_ok(["vcfdistance"], variants(4));
+is $output, $header . <<'', "distances for 4 variant lines, two references";
+ref1	502	.	G	A	38553	PASS	
+ref2	552	.	G	A	24044	PASS	BasesToClosestVariant=108;
+ref2	660	.	G	A	38553	PASS	BasesToClosestVariant=18;
+ref2	678	.	G	A	24044	PASS	BasesToClosestVariant=18;
+
+($output) = run_ok(["vcfdistance"], variants(3));
+is $output, $header . <<'', "distances for 3 variant lines, two references";
+ref1	502	.	G	A	38553	PASS	
+ref2	552	.	G	A	24044	PASS	BasesToClosestVariant=108;
+ref2	660	.	G	A	38553	PASS	BasesToClosestVariant=108;
+
+($output) = run_ok(["vcfdistance"], variants(2));
+is $output, $header . <<'', "distances for 2 variant lines, two references";
+ref1	502	.	G	A	38553	PASS	
+ref2	552	.	G	A	24044	PASS	
 
 done_testing;

--- a/tests/vcfdistance.t
+++ b/tests/vcfdistance.t
@@ -1,0 +1,57 @@
+use strict;
+use warnings;
+use Test::More;
+use Local::vcflib::Test;
+
+my @vcf = split /\n/, <<'';
+##fileformat=VCFv4.0
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+refseq	502	.	G	A	38553	PASS	
+refseq	552	.	G	A	24044	PASS	
+refseq	660	.	G	A	38553	PASS	
+refseq	678	.	G	A	24044	PASS	
+refseq	684	.	G	A	24044	PASS	
+
+sub variants {
+    join "\n", @vcf[0 .. $_[0] + 1]
+}
+
+my ($output, $header) = ('', <<'');
+##fileformat=VCFv4.0
+##INFO=<ID=BasesToClosestVariant,Number=1,Type=Integer,Description="Number of bases to the closest variant in the file.">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+
+($output) = run_ok(["vcfdistance"], variants(5));
+is $output, $header . <<'', "distances for 5 variant lines";
+refseq	502	.	G	A	38553	PASS	BasesToClosestVariant=50;
+refseq	552	.	G	A	24044	PASS	BasesToClosestVariant=50;
+refseq	660	.	G	A	38553	PASS	BasesToClosestVariant=18;
+refseq	678	.	G	A	24044	PASS	BasesToClosestVariant=6;
+refseq	684	.	G	A	24044	PASS	BasesToClosestVariant=6;
+
+($output) = run_ok(["vcfdistance"], variants(4));
+is $output, $header . <<'', "distances for 4 variant lines";
+refseq	502	.	G	A	38553	PASS	BasesToClosestVariant=50;
+refseq	552	.	G	A	24044	PASS	BasesToClosestVariant=50;
+refseq	660	.	G	A	38553	PASS	BasesToClosestVariant=18;
+refseq	678	.	G	A	24044	PASS	BasesToClosestVariant=18;
+
+($output) = run_ok(["vcfdistance"], variants(3));
+is $output, $header . <<'', "distances for 3 variant lines";
+refseq	502	.	G	A	38553	PASS	BasesToClosestVariant=50;
+refseq	552	.	G	A	24044	PASS	BasesToClosestVariant=50;
+refseq	660	.	G	A	38553	PASS	BasesToClosestVariant=108;
+
+($output) = run_ok(["vcfdistance"], variants(2));
+is $output, $header . <<'', "distances for 2 variant lines";
+refseq	502	.	G	A	38553	PASS	BasesToClosestVariant=50;
+refseq	552	.	G	A	24044	PASS	BasesToClosestVariant=50;
+
+($output) = run_ok(["vcfdistance"], variants(1));
+is $output, $header . <<'', "distances for 1 variant line";
+refseq	502	.	G	A	38553	PASS	
+
+($output) = run_ok(["vcfdistance"], variants(0));
+is $output, $header, "distances for 0 variant lines";
+
+done_testing;


### PR DESCRIPTION
This fixes various bugs in vcfdistance's handling of edge cases of 0-3 variants as well as correcting a doubly-added tag value and a minor bit of documentation.

Automated tests are added to demonstrate what's broken and ensure that it stays fixed.  You can run tests with `make test`.  They require perl + the IPC::Run3 module from CPAN.  This module is the only dependency not shipped with core Perl.
