### PR TITLE
Possible bug fix in vcffixup.cpp, where it would terminate with core dum...

### DIFF
--- a/src/vcffixup.cpp
+++ b/src/vcffixup.cpp
@@ -43,14 +43,14 @@ int countAlleles(Variant& var) {
 
 int main(int argc, char** argv) {
 
-    if (argc > 1 && (argv[1] == "-h" || argv[1] == "--help")) {
+  if (argc == 1 || ((argc > 1) && strcmp(argv[1], "-h") == 0) || strcmp(argv[1], "--help") == 0) {
         cerr << "usage: " << argv[0] << " <vcf file>" << endl
              << "outputs a VCF stream where AC and NS have been generated for each record using sample genotypes" << endl;
         return 1;
     }
 
     VariantCallFile variantFile;
-    if (argc == 1 || (argc == 2 && argv[1] == "-")) {
+    if (argc == 1 || ((argc == 2) && strcmp(argv[1], "-") == 0)) {
         variantFile.open(std::cin);
         if (!variantFile.is_open()) {
             cerr << "vcffixup: could not open stdin" << endl;


### PR DESCRIPTION
vcffixup.cpp would compile but when tried to execute, exits with core dump

```
 $ /share/apps/vcflib/bin/vcffixup -h
  terminate called after throwing an instance of 'std::out_of_range'
   what():  basic_string::substr
  Aborted (core dumped)

 $ gdb /share/apps/vcflib/bin/vcffixup core.5796 
 GNU gdb (GDB) Red Hat Enterprise Linux (7.2-50.el6)
 Copyright (C) 2010 Free Software Foundation, Inc.
 License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
 This is free software: you are free to change and redistribute it.
 There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
 and "show warranty" for details.
 This GDB was configured as "x86_64-redhat-linux-gnu".
 For bug reporting instructions, please see:
 <http://www.gnu.org/software/gdb/bugs/>...
 Reading symbols from /share/apps/vcflib/bin/vcffixup...done.
 [New Thread 5796]
 Missing separate debuginfo for 
 Try: yum --disablerepo='*' --enablerepo='*-debuginfo' install /usr/lib/debug/.build-     id/08/f634a1d22deff00461d50a7699dacdc97657bf
 Reading symbols from /lib64/libz.so.1...(no debugging symbols found)...done.
 Loaded symbols for /lib64/libz.so.1
 Reading symbols from /usr/lib64/libstdc++.so.6...(no debugging symbols found)...done.
 Loaded symbols for /usr/lib64/libstdc++.so.6
 Reading symbols from /lib64/libm.so.6...(no debugging symbols found)...done.
 Loaded symbols for /lib64/libm.so.6
 Reading symbols from /lib64/libgcc_s.so.1...(no debugging symbols found)...done.
 Loaded symbols for /lib64/libgcc_s.so.1
 Reading symbols from /lib64/libc.so.6...(no debugging symbols found)...done.
 Loaded symbols for /lib64/libc.so.6
 Reading symbols from /lib64/ld-linux-x86-64.so.2...(no debugging symbols found)...done.
 Loaded symbols for /lib64/ld-linux-x86-64.so.2
 Core was generated by `/share/apps/vcflib/bin/vcffixup -h'.
 Program terminated with signal 6, Aborted.
 #0  0x0000003768232885 in raise () from /lib64/libc.so.6
 Missing separate debuginfos, use: debuginfo-install glibc-2.12-1.47.el6.x86_64 libgcc-4.4.6-3.el6.x86_64      libstdc++-4.4.6-3.el6.x86_64 zlib-1.2.3-27.el6.x86_64
 (gdb) where
 #0  0x0000003768232885 in raise () from /lib64/libc.so.6
 #1  0x0000003768234065 in abort () from /lib64/libc.so.6
 #2  0x000000376b6bea7d in __gnu_cxx::__verbose_terminate_handler() () from /usr/lib64/libstdc++.so.6
 #3  0x000000376b6bcc06 in ?? () from /usr/lib64/libstdc++.so.6
 #4  0x000000376b6bcc33 in std::terminate() () from /usr/lib64/libstdc++.so.6
 #5  0x000000376b6bcd2e in __cxa_throw () from /usr/lib64/libstdc++.so.6
 #6  0x000000376b661dd7 in std::__throw_out_of_range(char const*) () from /usr/lib64/libstdc++.so.6
 #7  0x000000376b69d163 in std::basic_string<char, std::char_traits<char>, std::allocator<char> >::substr(unsigned long, unsigned long) const () from /usr/lib64/libstdc++.so.6
 #8  0x000000000040bb33 in vcf::VariantCallFile::parseHeader (this=0x7fff02aa00a0, hs="") at      src/Variant.cpp:1178
 #9  0x000000000040baac in vcf::VariantCallFile::parseHeader (this=0x7fff02aa00a0) at src/Variant.cpp:1172
 #10 0x0000000000456209 in vcf::VariantCallFile::openFile (this=0x7fff02aa00a0, filename="-h") at src/Variant.h:100
 #11 0x000000000045617a in vcf::VariantCallFile::open (this=0x7fff02aa00a0, filename="-h") at src/Variant.h:93
 #12 0x00000000004550bd in main (argc=2, argv=0x7fff02aa0da8) at src/vcffixup.cpp:61
```

Committed change seems to work.

```
 $ g++ src/Variant.o src/split.o smithwaterman/SmithWatermanGotoh.o  smithwaterman/Repeats.o smithwaterman/disorder.c smithwaterman/LeftAlign.o smithwaterman/IndelAllele.o src/ssw.o src/ssw_cpp.o fastahack/Fasta.o fsom/fsom.o filevercmp/filevercmp.o tabixpp/tabix.o tabixpp/bgzf.o src/vcffixup.cpp -o bin/vcffixup -I. -L. -Ltabixpp/ -ltabix -lz -lm  -O3 -D_FILE_OFFSET_BITS=64 -g -O0
 $ /share/apps/vcflib/bin/vcffixup 
 usage: /share/apps/vcflib/bin/vcffixup <vcf file>
 outputs a VCF stream where AC and NS have been generated for each record using sample genotypes
 $ /share/apps/vcflib/bin/vcffixup -h
 usage: /share/apps/vcflib/bin/vcffixup <vcf file>
 outputs a VCF stream where AC and NS have been generated for each record using sample genotypes
```
