### PR TITLE
Case-insensitive comparitor for map; don't tolower find

### DIFF
--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -2323,8 +2323,6 @@ vector<Variant*> Variant::matchingHaplotypes() {
         // get the meta_line unique key (first chars before the =)
         unsigned int meta_line_index = meta_line.find("=", 0);
         string meta_line_prefix = meta_line.substr(0, meta_line_index);
-        // all map keys are lower case so when we check we need to be lower case too!
-        std::transform(meta_line_prefix.begin(), meta_line_prefix.end(), meta_line_prefix.begin(), ::tolower);
 
         // check if the meta_line_prefix is in the header_lines, if so add it to the appropirate list
         if (this->header_lines.find(meta_line_prefix) != header_lines.end()) // the meta_line is a header line so replace what was there

--- a/src/Variant.h
+++ b/src/Variant.h
@@ -557,8 +557,27 @@ private:
      * Duplicates are not allowed, to prevent duplicates use addHeaderColumn when adding header columns
      */
     vector<string> header_columns;
-    map<string, string> header_lines; // contains all the ##_types_ as keys, the value is either empty or a VCF file has set it
-    map< string, vector<string> > header_lists; // contains all the ##_types_ as keys, the value is a vector of ##_type_ (since there can be duplicate #INFO for example, duplicate ids are not allowed)
+
+    /* 
+     * the maps we're going to be using will be case-insensitive
+     * so that "fileFormat" and "fileformat" hash to the same item.
+     */
+    struct stringcasecmp : binary_function<string, string, bool> {
+        struct charcasecmp : public std::binary_function<unsigned char, unsigned char, bool> {
+            bool operator() (const unsigned char& c1, const unsigned char& c2) const {
+                return tolower (c1) < tolower (c2); 
+            }
+        };
+        bool operator() (const std::string & s1, const std::string & s2) const {
+            return std::lexicographical_compare(s1.begin(), s1.end(), s2.begin(), s2.end(), charcasecmp());
+        }
+    };
+
+    // contains all the ##_types_ as keys, the value is either empty or a VCF file has set it
+    map<string, string, stringcasecmp> header_lines; 
+
+    // contains all the ##_types_ as keys, the value is a vector of ##_type_ (since there can be duplicate #INFO for example, duplicate ids are not allowed)
+    map<string, vector<string>, stringcasecmp> header_lists; 
 
 };
 


### PR DESCRIPTION
Bigger change to address #65 - use case-insensitive comparitor for header_lines and header_lists maps so that case sensitivity isn't an issue.
