### PR TITLE
Tool to normalize genotype/FORMAT fields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ BIN_SOURCES = src/vcfecho.cpp \
 			  src/vcfgenosummarize.cpp \
 			  src/vcfgenosamplenames.cpp \
 			  src/vcfgeno2haplo.cpp \
+			  src/vcfgenoexpandnull.cpp \
 			  src/vcfleftalign.cpp \
 			  src/vcfcombine.cpp \
 			  src/vcfgeno2alleles.cpp \

--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -80,10 +80,10 @@ void Variant::parse(string& line, bool parseSamples) {
                 // trailing fields may be dropped according to vcf4.2 spec, so allow that
                 if( i != samplefields.end() ){
                     samples[name][*f] = split(*i, ',');
+                    ++i;
                 }else{
                     samples[name][*f].push_back(".");
                 }
-                ++i;
             }
         }
         if (sampleName != sampleNames.end()) {

--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -76,19 +76,14 @@ void Variant::parse(string& line, bool parseSamples) {
             }
             vector<string> samplefields = split(*sample, ':');
             vector<string>::iterator i = samplefields.begin();
-            if (samplefields.size() != format.size()) {
-                // ignore this case... malformed (or 'null') sample specs are caught above
-                // /*
-                // cerr << "inconsistent number of fields for sample " << name << endl
-                //      << "format is " << join(format, ":") << endl
-                //      << "sample is " << *sample << endl;
-                // exit(1);
-                // *
-            }
-            else {
-                for (vector<string>::iterator f = format.begin(); f != format.end(); ++f) {
-                    samples[name][*f] = split(*i, ','); ++i;
+            for (vector<string>::iterator f = format.begin(); f != format.end(); ++f) {
+                // trailing fields may be dropped according to vcf4.2 spec, so allow that
+                if( i != samplefields.end() ){
+                    samples[name][*f] = split(*i, ',');
+                }else{
+                    samples[name][*f].push_back(".");
                 }
+                ++i;
             }
         }
         if (sampleName != sampleNames.end()) {

--- a/src/vcfgenoexpandnull.cpp
+++ b/src/vcfgenoexpandnull.cpp
@@ -1,0 +1,153 @@
+#include "Variant.h"
+#include "split.h"
+#include <getopt.h>
+#include <string>
+#include <iostream>
+
+using namespace std;
+using namespace vcflib;
+
+void printSummary(char** argv) {
+    cerr << "usage: " << argv[0] << " [options] <vcf file>" << endl
+         << endl
+         << "options:" << endl
+         << "    -p, --ploidy N   the polidy of missing/null GT fields (default=2)"
+         << "    -L, --expand_GL  fill in missing GL fields with 0 values (eg: 0,0,0 for diploid 2 alleles)"
+         << endl
+         << "Makes the FORMAT for each variant line the same (uses all the FORMAT fields described in the header)."
+         << endl
+         << "Fills out per-sample fields to match FORMAT."
+         << endl
+         << "Expands GT values of '.' with number of alleles based on ploidy (eg: './.' for dipolid)."
+            
+         << endl;
+    exit(0);
+}
+
+int nChoosek(int n, int k){
+    if (k > n) return 0;
+    if (k*2 > n) k = n-k;
+    if (k == 0) return 1;
+    int result = n;
+    for( int i = 2; i <= k; ++i ){
+        result *= (n-i+1);
+        result /= i;
+    }
+    return result;
+}
+
+int main(int argc, char** argv) {
+    int ploidy = 2;
+    bool expand_GL = false;
+
+    int c;
+    while (true) {
+        static struct option long_options[] =
+            {
+                /* These options set a flag. */
+                //{"verbose", no_argument,       &verbose_flag, 1},
+                {"help", no_argument, 0, 'h'},
+                {"expand_GL", no_argument, 0, 'L'},
+                {"ploidy", required_argument, 0, 'p'},
+                {0, 0, 0, 0}
+            };
+        /* getopt_long stores the option index here. */
+        int option_index = 0;
+        c = getopt_long (argc, argv, "hp:L", long_options, &option_index);
+        if (c == -1)
+            break;
+        switch (c) {
+
+        case 'p':
+            ploidy = atoi(optarg);
+            break;
+        case 'L':
+            expand_GL = true;
+            break;
+        case 'h':
+        default:
+            printSummary(argv);
+            break;
+        }
+    }
+
+    VariantCallFile variantFile;
+
+    variantFile.open(std::cin);
+
+    if (!variantFile.is_open()) {
+        return 1;
+    }
+
+    cout << variantFile.header << endl;
+
+    vector<string> null_val_vector;
+    null_val_vector.push_back(".");
+
+    vector<string> null_GTval_vector;
+    null_GTval_vector.push_back(".");
+    for( int i=1; i<ploidy; ++i ){
+        null_GTval_vector.back() += "/.";
+    }
+
+    vector<string> null_GLval_vector;
+    null_GLval_vector.push_back(".");
+
+    Variant var(variantFile);
+
+    vector<string> out_formats;
+    out_formats.push_back("GT"); // always include GT first
+
+    map<string, vector<string> > full_null_val; // values to set missing genotypes ('.') with
+    full_null_val.insert(pair<string,vector<string> >("GT", null_GTval_vector));
+
+    for( map<string, VariantFieldType>::iterator formats = variantFile.formatTypes.begin();
+        formats != variantFile.formatTypes.end();
+        ++formats ){
+        if( formats->first != "GT" ){
+            out_formats.push_back(formats->first);
+            full_null_val.insert(pair<string,vector<string> >(formats->first, null_val_vector));
+        }
+    }
+
+    int last_num_alleles = -1;
+    while (variantFile.getNextVariant(var)) {
+
+        // make the expanded null/empty GL value if we need it (varies by num alleles)
+        if( expand_GL && last_num_alleles != var.alleles.size() ){
+            last_num_alleles = var.alleles.size();
+            null_GLval_vector.back() = "0";
+            for( int i=1; i<nChoosek(var.alleles.size()+ploidy-1, ploidy); ++i ){
+                null_GLval_vector.back() += ",0";
+            }
+            full_null_val["GL"] = null_GLval_vector;
+        }
+
+        for( vector<string>::iterator sample_name=var.sampleNames.begin(); sample_name != var.sampleNames.end(); ++sample_name ){
+            map<string, map<string, vector<string> > >::iterator sample_it = var.samples.find(*sample_name);
+            if( sample_it == var.samples.end() ){
+                // add missing ('.') samples back with null values
+                var.samples.insert(pair<string, map<string, vector<string> > >(*sample_name, full_null_val));
+            }else{
+                for( vector<string>::iterator fit = out_formats.begin(); fit != out_formats.end(); ++fit ){
+                    if( sample_it->second.find(*fit) == sample_it->second.end() ){ // missing key, should't happen but check anyway
+                        vector<string>& val = null_val_vector; // fill any missing keys with null values
+                    }
+                    if( expand_GL ){
+                        map<string, vector<string> >::iterator val_it = sample_it->second.find("GL");
+                        if( val_it == sample_it->second.end() || val_it->second.back() == "." ){
+                            sample_it->second["GL"] = null_GLval_vector;
+                        }
+                    }
+                }
+            }
+
+        }
+
+        var.format = out_formats; // set FORMAT so it is the same for all variants
+        cout << var << endl;
+    }
+    return 0;
+
+}
+


### PR DESCRIPTION
Changed Variant.cpp so it will accept genotypes which omit trailing fields (as per the vcf specification).  Just fills in those missing fields as '.'

Also added a tool `vcfgenoexpandnull` which:
- Changes the FORMAT for each variant line to be all the FORMAT fields described in the header
- Recodes missing GT fields from '.' to './.' (or whatever is correct for the `--ploidy` argument)
- Expands the genotypes so all other missing values are replaces with a '.'
- Optionally sets missing GL fields to be a list of 0s (eg: '0,0,0' for diploid 2 alleles) as opposed to just setting it to '.'  (This makes it a more robust/general replacement for `vcfnulldotslashdot`.)

The use case is when dealing with downstream programs which interpret a single '.' for a no-call sample (like currently freebayes produces) as GT='.' (ie: uncalled haploid).  It should also help with some downstream programs which assume things like FORMAT is the same for all lines or every sample has a GL field.

PS: The name (and help text) aren't very good IMO.  I can't come up with better though. 
