### PR TITLE
Remove -ltabix because tabixhpp doesnt put anything in it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ FSOM = fsom/fsom.o
 FILEVERCMP = filevercmp/filevercmp.o
 
 INCLUDES = -I. -Itabixpp/htslib/ -L. -Ltabixpp/ -Ltabixpp/htslib/
-LDFLAGS = -lvcflib -ltabix -lhts -lpthread -lz -lm
+LDFLAGS = -lvcflib -lhts -lpthread -lz -lm
 
 
 all: $(OBJECTS) $(BINS)


### PR DESCRIPTION
Also: Please update tabixpp submodule to reflect recent pull request to remove libtabix.a completely.

Note: This is pull request 2 of 3 to get VG building on Mac. 
