### PR TITLE
Keep phasing when annotating genotypes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,168 @@
+cmake_minimum_required(VERSION 2.6)
+project(vcflib)
+
+include(ExternalProject)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -D_FILE_OFFSET_BITS=64")
+
+include_directories(include)
+include_directories(tabixpp)
+include_directories(fastahack)
+include_directories(intervaltree)
+include_directories(smithwaterman)
+include_directories(multichoose)
+include_directories(filevercmp)
+
+add_library(vcflib STATIC 
+    src/Variant.h 
+    src/split.h 
+    src/pdflib.hpp 
+    src/var.hpp 
+    src/cdflib.hpp 
+    src/rnglib.hpp 
+    src/join.h
+    src/Variant.cpp 
+    src/rnglib.cpp 
+    src/var.cpp 
+    src/pdflib.cpp 
+    src/cdflib.cpp 
+    src/split.cpp
+    src/ssw.h
+    src/ssw_cpp.h
+    tabixpp/tabix.cpp
+    fastahack/Fasta.cpp
+    smithwaterman/SmithWatermanGotoh.cpp
+    smithwaterman/Repeats.cpp
+    smithwaterman/IndelAllele.cpp
+    smithwaterman/disorder.cpp
+    smithwaterman/LeftAlign.cpp
+    fsom/fsom.c
+    filevercmp/filevercmp.c
+    )
+
+set(BINS 
+    vcfecho
+    dumpContigsFromHeader
+    bFst
+    pVst
+    hapLrt
+    popStats
+    wcFst
+    iHS
+    segmentFst
+    segmentIhs
+    genotypeSummary
+    sequenceDiversity
+    pFst
+    smoother
+    LD
+    plotHaps
+    abba-baba
+    permuteGPAT++
+    permuteSmooth
+    normalize-iHS
+    meltEHH
+    vcfaltcount
+    vcfhetcount
+    vcfhethomratio
+    vcffilter
+    vcf2tsv
+    vcfgenotypes
+    vcfannotategenotypes
+    vcfcommonsamples
+    vcfremovesamples
+    vcfkeepsamples
+    vcfsamplenames
+    vcfgenotypecompare
+    vcffixup
+    vcfclassify
+    vcfsamplediff
+    vcfremoveaberrantgenotypes
+    vcfrandom
+    vcfparsealts
+    vcfstats
+    vcfflatten
+    vcfprimers
+    vcfnumalt
+    vcfcleancomplex
+    vcfintersect
+    vcfannotate
+    vcfallelicprimitives
+    vcfoverlay
+    vcfaddinfo
+    vcfkeepinfo
+    vcfkeepgeno
+    vcfafpath
+    vcfcountalleles
+    vcflength
+    vcfdistance
+    vcfrandomsample
+    vcfentropy
+    vcfglxgt
+    vcfroc
+    vcfcheck
+    vcfstreamsort
+    vcfuniq
+    vcfuniqalleles
+    vcfremap
+    vcf2fasta
+    vcfsitesummarize
+    vcfbreakmulti
+    vcfcreatemulti
+    vcfevenregions
+    vcfcat
+    vcfgenosummarize
+    vcfgenosamplenames
+    vcfgeno2haplo
+    vcfleftalign
+    vcfcombine
+    vcfgeno2alleles
+    vcfindex
+    vcf2dag
+    vcfsample2info
+    vcfqual2info
+    vcfinfo2qual
+    vcfglbound
+    vcfinfosummarize)
+
+execute_process(COMMAND git describe --abbrev=4 --dirty --always 
+  OUTPUT_VARIABLE GIT_VERSION 
+  WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+ExternalProject_Add(htslib-build
+  SOURCE_DIR ${CMAKE_SOURCE_DIR}/tabixpp/htslib
+  BINARY_DIR ${CMAKE_SOURCE_DIR}/tabixpp/htslib
+  PREFIX ${CMAKE_CURRENT_BINARY_DIR}/htslib
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND make lib-static
+  INSTALL_COMMAND ""
+  )
+
+add_library(htslib STATIC IMPORTED)
+set_property(TARGET htslib PROPERTY 
+  IMPORTED_LOCATION ${CMAKE_SOURCE_DIR}/tabixpp/htslib/libhts.a)
+add_dependencies(htslib htslib-build)
+
+find_package(ZLIB REQUIRED)
+find_package(Threads REQUIRED)
+
+foreach(BIN ${BINS})
+  add_executable(${BIN} src/${BIN}.cpp)
+  target_link_libraries(${BIN} vcflib htslib ${CMAKE_THREAD_LIBS_INIT} ${ZLIB_LIBRARIES})
+  target_compile_definitions(${BIN} PRIVATE -DVERSION="${GIT_VERSION}")
+endforeach(BIN ${BINS})
+
+install(TARGETS ${BINS} RUNTIME DESTINATION bin)
+install(TARGETS vcflib ARCHIVE DESTINATION lib)
+
+file(GLOB INCLUDES
+  src/*.h*
+  multichoose/*.h*
+  intervaltree/*.h*
+  tabixpp/*.h*
+  smithwaterman/*.h*
+  fastahack/*.h*
+  filevercmp/*.h*)
+
+install(FILES ${INCLUDES} DESTINATION include)

--- a/Makefile
+++ b/Makefile
@@ -1,148 +1,16 @@
-#OBJ_DIR = ./
-HEADERS = src/Variant.h \
-		  src/split.h \
-		  src/pdflib.hpp \
-		  src/var.hpp \
-                  src/cdflib.hpp \
-		  src/rnglib.hpp \
-		  src/join.h
-SOURCES = src/Variant.cpp \
-		  src/rnglib.cpp \
-		  src/var.cpp \
-		  src/pdflib.cpp \
-		  src/cdflib.cpp \
-		  src/split.cpp
-OBJECTS= $(SOURCES:.cpp=.o)
-
 VCF_LIB_LOCAL:=$(shell pwd)
-BIN_DIR:=bin
-LIB_DIR:=lib
-SRC_DIR=src
-INC_DIR:=include
-OBJ_DIR:=obj
+BUILD_DIR:=$(VCF_LIB_LOCAL)/build
+BIN_DIR:=$(VCF_LIB_LOCAL)/bin
+LIB_DIR:=$(VCF_LIB_LOCAL)/lib
+SRC_DIR=$(VCF_LIB_LOCAL)/src
+INC_DIR:=$(VCF_LIB_LOCAL)/include
+OBJ_DIR:=$(VCF_LIB_LOCAL)/obj
 
 # TODO
-#vcfstats.cpp
 
-BIN_SOURCES = src/vcfecho.cpp \
-			  src/dumpContigsFromHeader.cpp \
-			  src/bFst.cpp \
-			  src/pVst.cpp \
-			  src/hapLrt.cpp \
-			  src/popStats.cpp \
-			  src/wcFst.cpp \
-			  src/iHS.cpp \
-			  src/segmentFst.cpp \
-			  src/segmentIhs.cpp \
-			  src/genotypeSummary.cpp \
-			  src/sequenceDiversity.cpp \
-			  src/pFst.cpp \
-			  src/smoother.cpp \
-			  src/LD.cpp \
-			  src/plotHaps.cpp \
-			  src/abba-baba.cpp \
-			  src/permuteGPAT++.cpp \
-			  src/permuteSmooth.cpp \
-			  src/normalize-iHS.cpp \
-			  src/meltEHH.cpp \
-			  src/vcfaltcount.cpp \
-			  src/vcfhetcount.cpp \
-			  src/vcfhethomratio.cpp \
-			  src/vcffilter.cpp \
-			  src/vcf2tsv.cpp \
-			  src/vcfgenotypes.cpp \
-			  src/vcfannotategenotypes.cpp \
-			  src/vcfcommonsamples.cpp \
-			  src/vcfremovesamples.cpp \
-			  src/vcfkeepsamples.cpp \
-			  src/vcfsamplenames.cpp \
-			  src/vcfgenotypecompare.cpp \
-			  src/vcffixup.cpp \
-			  src/vcfclassify.cpp \
-			  src/vcfsamplediff.cpp \
-			  src/vcfremoveaberrantgenotypes.cpp \
-			  src/vcfrandom.cpp \
-			  src/vcfparsealts.cpp \
-			  src/vcfstats.cpp \
-			  src/vcfflatten.cpp \
-			  src/vcfprimers.cpp \
-			  src/vcfnumalt.cpp \
-			  src/vcfcleancomplex.cpp \
-			  src/vcfintersect.cpp \
-			  src/vcfannotate.cpp \
-			  src/vcfallelicprimitives.cpp \
-			  src/vcfoverlay.cpp \
-			  src/vcfaddinfo.cpp \
-			  src/vcfkeepinfo.cpp \
-			  src/vcfkeepgeno.cpp \
-			  src/vcfafpath.cpp \
-			  src/vcfcountalleles.cpp \
-			  src/vcflength.cpp \
-			  src/vcfdistance.cpp \
-			  src/vcfrandomsample.cpp \
-			  src/vcfentropy.cpp \
-			  src/vcfglxgt.cpp \
-			  src/vcfroc.cpp \
-			  src/vcfcheck.cpp \
-			  src/vcfstreamsort.cpp \
-			  src/vcfuniq.cpp \
-			  src/vcfuniqalleles.cpp \
-			  src/vcfremap.cpp \
-			  src/vcf2fasta.cpp \
-			  src/vcfsitesummarize.cpp \
-			  src/vcfbreakmulti.cpp \
-			  src/vcfcreatemulti.cpp \
-			  src/vcfevenregions.cpp \
-			  src/vcfcat.cpp \
-			  src/vcfgenosummarize.cpp \
-			  src/vcfgenosamplenames.cpp \
-			  src/vcfgeno2haplo.cpp \
-			  src/vcfleftalign.cpp \
-			  src/vcfcombine.cpp \
-			  src/vcfgeno2alleles.cpp \
-			  src/vcfindex.cpp \
-			  src/vcf2dag.cpp \
-			  src/vcfsample2info.cpp \
-			  src/vcfqual2info.cpp \
-			  src/vcfinfo2qual.cpp \
-			  src/vcfglbound.cpp \
-			  src/vcfinfosummarize.cpp
-
-# when we can figure out how to build on mac
-# src/vcfsom.cpp
-
-#BINS = $(BIN_SOURCES:.cpp=)
-BINS = $(addprefix bin/,$(notdir $(BIN_SOURCES:.cpp=)))
-SHORTBINS = $(notdir $(BIN_SOURCES:.cpp=))
-
-TABIX = tabixpp/tabix.o
-FASTAHACK = fastahack/Fasta.o
-SMITHWATERMAN = smithwaterman/SmithWatermanGotoh.o
-REPEATS = smithwaterman/Repeats.o
-INDELALLELE = smithwaterman/IndelAllele.o
-DISORDER = smithwaterman/disorder.o
-LEFTALIGN = smithwaterman/LeftAlign.o
-FSOM = fsom/fsom.o
-FILEVERCMP = filevercmp/filevercmp.o
-
-INCLUDES = -Itabixpp/htslib -I$(INC_DIR) -L. -Ltabixpp/htslib
-LDFLAGS = -L$(LIB_DIR) -lvcflib -lhts -lpthread -lz -lm
-
-
-all: $(OBJECTS) $(BINS)
-
-
-GIT_VERSION := $(shell git describe --abbrev=4 --dirty --always)
-
-CXX = g++
-CXXFLAGS = -O3 -D_FILE_OFFSET_BITS=64 -std=c++0x 
-#CXXFLAGS = -O2
-#CXXFLAGS = -pedantic -Wall -Wshadow -Wpointer-arith -Wcast-qual
-
-SSW = src/ssw.o src/ssw_cpp.o
-
-ssw.o: src/ssw.h
-ssw_cpp.o:src/ssw_cpp.h
+all: 
+	if [ ! -d $(BUILD_DIR) ]; then mkdir -p $(BUILD_DIR); fi
+	cd $(BUILD_DIR); cmake -DCMAKE_INSTALL_PREFIX=$(VCF_LIB_LOCAL) $(VCF_LIB_LOCAL); $(MAKE) && $(MAKE) install
 
 openmp:
 	$(MAKE) CXXFLAGS="$(CXXFLAGS) -fopenmp -D HAS_OPENMP"
@@ -153,58 +21,8 @@ profiling:
 gprof:
 	$(MAKE) CXXFLAGS="$(CXXFLAGS) -pg" all
 
-$(OBJECTS): $(SOURCES) $(HEADERS) $(TABIX) multichoose pre $(SMITHWATERMAN) $(FILEVERCMP)
-	$(CXX) -c -o $@ src/$(*F).cpp $(INCLUDES) $(LDFLAGS) $(CXXFLAGS) && cp src/*.h* $(VCF_LIB_LOCAL)/$(INC_DIR)/
-
-multichoose: pre
-	cd multichoose && $(MAKE) && cp *.h* $(VCF_LIB_LOCAL)/$(INC_DIR)/
-
-intervaltree: pre
-	cd intervaltree && $(MAKE) && cp *.h* $(VCF_LIB_LOCAL)/$(INC_DIR)/
-
-$(TABIX): pre
-	cd tabixpp && $(MAKE) && cp *.h* $(VCF_LIB_LOCAL)/$(INC_DIR)/
-
-$(SMITHWATERMAN): pre
-	cd smithwaterman && $(MAKE) && cp *.h* $(VCF_LIB_LOCAL)/$(INC_DIR)/ && cp *.o $(VCF_LIB_LOCAL)/$(OBJ_DIR)/
-
-$(DISORDER): $(SMITHWATERMAN)
-
-$(REPEATS): $(SMITHWATERMAN)
-
-$(LEFTALIGN): $(SMITHWATERMAN)
-
-$(INDELALLELE): $(SMITHWATERMAN)
-
-$(FASTAHACK): pre
-	cd fastahack && $(MAKE) && cp *.h* $(VCF_LIB_LOCAL)/$(INC_DIR)/ && cp Fasta.o $(VCF_LIB_LOCAL)/$(OBJ_DIR)/
-
-#$(FSOM):
-#	cd fsom && $(CXX) $(CXXFLAGS) -c fsom.c -lm
-
-$(FILEVERCMP): pre
-	cd filevercmp && make && cp *.h* $(VCF_LIB_LOCAL)/$(INC_DIR)/ && cp *.o $(VCF_LIB_LOCAL)/$(INC_DIR)/
-
-$(SHORTBINS): pre
-	$(MAKE) bin/$@
-
-$(BINS): $(BIN_SOURCES) libvcflib.a $(OBJECTS) $(SMITHWATERMAN) $(FASTAHACK) $(DISORDER) $(LEFTALIGN) $(INDELALLELE) $(SSW) $(FILEVERCMP) pre intervaltree
-	$(CXX) src/$(notdir $@).cpp -o $@ $(INCLUDES) $(LDFLAGS) $(CXXFLAGS) -DVERSION=\"$(GIT_VERSION)\"
-
-libvcflib.a: $(OBJECTS) $(SMITHWATERMAN) $(REPEATS) $(FASTAHACK) $(DISORDER) $(LEFTALIGN) $(INDELALLELE) $(SSW) $(FILEVERCMP) $(TABIX) pre
-	ar rs libvcflib.a $(OBJECTS) smithwaterman/sw.o $(FASTAHACK) $(SSW) $(FILEVERCMP) $(TABIX)
-	cp libvcflib.a $(LIB_DIR)
-
-
 test: $(BINS)
 	@prove -Itests/lib -w tests/*.t
-
-pre:
-	if [ ! -d $(BIN_DIR) ]; then mkdir -p $(BIN_DIR); fi
-	if [ ! -d $(LIB_DIR) ]; then mkdir -p $(LIB_DIR); fi
-	if [ ! -d $(INC_DIR) ]; then mkdir -p $(INC_DIR); fi
-	if [ ! -d $(OBJ_DIR) ]; then mkdir -p $(OBJ_DIR); fi
-
 
 pull:
 	git pull

--- a/src/vcfannotategenotypes.cpp
+++ b/src/vcfannotategenotypes.cpp
@@ -55,17 +55,34 @@ void annotateWithGenotypes(Variant& varA, Variant& varB, string& annotationTag) 
             map<string, vector<string> >& other = o->second;
             string& otherGenotype = other["GT"].front();
             // XXX this must compare the genotypes in the two files
-            map<int, int> gtB = decomposeGenotype(otherGenotype);
-            map<int, int> gtnew;
-            for (map<int, int>::iterator g = gtB.begin(); g != gtB.end(); ++g) {
+           
+            if (otherGenotype.find("|") != string::npos) {
+              vector<int> gtB = decomposePhasedGenotype(otherGenotype);
+              vector<int> gtnew;
+              gtnew.reserve(gtB.size());
+
+              for (vector<int>::iterator g = gtB.begin(); g != gtB.end(); ++g) {
+                map<int, int>::iterator f = varBconvertToVarA.find(*g);
+                if (f != varBconvertToVarA.end()) {
+                  gtnew.push_back(*g);
+                } else {
+                  gtnew.push_back(NULL_ALLELE);
+                }
+              }
+              sample[annotationTag].push_back(phasedGenotypeToString(gtnew));
+            } else {
+              map<int, int> gtB = decomposeGenotype(otherGenotype);
+              map<int, int> gtnew;
+              for (map<int, int>::iterator g = gtB.begin(); g != gtB.end(); ++g) {
                 map<int, int>::iterator f = varBconvertToVarA.find(g->first);
                 if (f != varBconvertToVarA.end()) {
-                    gtnew[f->second] += g->second;
+                  gtnew[f->second] += g->second;
                 } else {
-                    gtnew[-1] += g->second;
+                  gtnew[NULL_ALLELE] += g->second;
                 }
+              }
+              sample[annotationTag].push_back(genotypeToString(gtnew));
             }
-            sample[annotationTag].push_back(genotypeToString(gtnew));
         }
     }
 }


### PR DESCRIPTION
Prior to this change, `vcfannotategenotypes` did not transfer over
genotype phasing, if it was present.

Fixes #143
