### PR TITLE
Don't override environment CXX settings with a hardcoded CXX variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,6 @@ scriptToBin: $(BINS)
 
 GIT_VERSION := $(shell git describe --abbrev=4 --dirty --always)
 
-CXX = g++
 CXXFLAGS = -O3 -D_FILE_OFFSET_BITS=64 -std=c++0x
 #CXXFLAGS = -O2
 #CXXFLAGS = -pedantic -Wall -Wshadow -Wpointer-arith -Wcast-qual


### PR DESCRIPTION
This is annoying to those who have lots of compilers installed.