### PR TITLE
Workarround g++-5 issue with ambiguous abs invocation. Stol return an…

### DIFF
--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -164,7 +164,7 @@ bool Variant::canonicalize_sv(FastaReference& fasta_reference, vector<FastaRefer
                             sv_len = (size_t) abs(stol(this->info["SVLEN"][alt_pos]));
                         }
                         else if (this->info.find("END") != this->info.end()){
-                            sv_len = abs((size_t) stol(this->info["END"][alt_pos]) - (size_t) (this->position));
+                            sv_len = (size_t) abs(stol(this->info["END"][alt_pos]) - (this->position));
                         }
                         else{
                             // If we have neither, we'll ignore it.


### PR DESCRIPTION
…d position are both long. Do not assume size_t is a long do that cast outside of the invocation

This should of course be applied after the previous pull request.

Closes  #177