### PR TITLE
Sv normal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ OBJ_DIR:=obj
 #vcfstats.cpp
 
 BIN_SOURCES = src/vcfecho.cpp \
+			  src/vcfnormalizesvs.cpp \
 			  src/dumpContigsFromHeader.cpp \
 			  src/bFst.cpp \
 			  src/pVst.cpp \

--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -3,6 +3,8 @@
 
 namespace vcflib {
 
+
+
 void Variant::parse(string& line, bool parseSamples) {
 
     // clean up potentially variable data structures
@@ -112,7 +114,7 @@ void Variant::parse(string& line, bool parseSamples) {
 bool Variant::canonicalize_sv(FastaReference& fasta_reference, vector<FastaReference*> insertions, int max_interval){
     
             bool variant_acceptable = true;
-            bool do_external_insertions = false;
+            bool do_external_insertions = !insertions.empty();
             size_t sv_len = 0;
             bool var_is_sv = false;
             FastaReference* insertion_fasta;
@@ -128,8 +130,7 @@ bool Variant::canonicalize_sv(FastaReference& fasta_reference, vector<FastaRefer
     };
 
 
-            if (insertions.size() == 1){
-                do_external_insertions = true;
+            if (do_external_insertions){
                 insertion_fasta = insertions[0];
 
             }
@@ -153,12 +154,12 @@ bool Variant::canonicalize_sv(FastaReference& fasta_reference, vector<FastaRefer
                             // SVLEN is the difference in length between REF and ALT alleles.
 
 
-                            if (!(this->info["SVTYPE"][alt_pos] == "INV" ||
+                        if (!(this->info["SVTYPE"][alt_pos] == "INV" ||
                                         this->info["SVTYPE"][alt_pos] == "DEL" ||
                                         this->info["SVTYPE"][alt_pos] == "INS") || this->alt.size() > 1){
                                 variant_acceptable = false;
                                 break;                                                                                                                                  
-                            }
+                        }
 
                         if (this->info.find("SVLEN") != this->info.end()){
                             sv_len = (size_t) abs(stol(this->info["SVLEN"][alt_pos]));
@@ -172,7 +173,7 @@ bool Variant::canonicalize_sv(FastaReference& fasta_reference, vector<FastaRefer
                             break;
                         }
 
-                        if (a == "<INS>" || this->info["SVTYPE"][alt_pos] == "INS"){
+                        if (this->info["SVTYPE"][alt_pos] == "INS" || a == "<INS>"){
                             this->ref.assign(fasta_reference.getSubSequence(this->sequenceName, this->position, 1));
                             if (this->alt[alt_pos] == "<INS>"){
                                 variant_acceptable = false;

--- a/src/vcfnormalizesvs.cpp
+++ b/src/vcfnormalizesvs.cpp
@@ -32,7 +32,7 @@ int main(int argc, char** argv) {
             };
         int option_index = 0;
 
-        c = getopt_long (argc, argv, "r:i:",
+        c = getopt_long (argc, argv, "r:i:h",
                          long_options, &option_index);
         if (c == -1)
             break;
@@ -49,8 +49,14 @@ int main(int argc, char** argv) {
             print_help(argv);
             exit(1);
         default:
+            print_help(argv);
             abort();
         }
+    }
+
+    if (argc < 2){
+        print_help(argv);
+        exit(1);
     }
 
  
@@ -82,7 +88,6 @@ int main(int argc, char** argv) {
     Variant var;
     while (variantFile.getNextVariant(var)) {
         bool valid = var.canonicalize_sv(ref, insertions, max_interval);
-        //bool valid = canonicalize_sv(FastaReference& ref, vector<FastaReference*> insertions, int interval_sz = -1);
         if (!valid){
             cerr << "Variant could not be normalized" << var << endl;
         }

--- a/src/vcfnormalizesvs.cpp
+++ b/src/vcfnormalizesvs.cpp
@@ -1,0 +1,95 @@
+#include "Variant.h"
+#include <getopt.h>
+#include "Fasta.h"
+
+using namespace std;
+using namespace vcflib;
+
+void print_help(char** argv){
+    cerr << "vcfnormalizesvs: Convert a VCF with representative alleles to one with canonical, sequence-based ref/alt alleles." << endl
+        << "usage: " << argv[0] << " [OPTIONS] var.vcf" << endl
+        << "Options: " << endl
+        << "   -r / --reference <ref.fa>   FASTA-format reference genome from which to pull SV sequences." << endl
+        << "   -i / --inserions <ins.fa>   FASTA-format insertion sequences, with IDs matching the ALT allele tags in the vcf" << endl
+        << endl;
+}
+
+int main(int argc, char** argv) {
+
+    
+    string ref_file = "";
+    vector<string> insertion_files;
+    int max_interval = -1;
+
+    int c = 0;
+    while (true) {
+        static struct option long_options[] =
+            {
+                {"insertions", no_argument, 0, 'i'},
+                {"help", no_argument, 0, 'h'},
+                {"reference", required_argument, 0, 'r'},
+                {0, 0, 0, 0}
+            };
+        int option_index = 0;
+
+        c = getopt_long (argc, argv, "r:i:",
+                         long_options, &option_index);
+        if (c == -1)
+            break;
+        /* Detect the end of the options. */
+        switch(c){
+        case 'r':
+            ref_file = optarg;
+            break;
+        case 'i':
+            insertion_files.push_back(optarg);
+            break;
+        case 'h':
+        case '?':
+            print_help(argv);
+            exit(1);
+        default:
+            abort();
+        }
+    }
+
+ 
+
+    VariantCallFile variantFile;
+    string filename = argv[argc - 1];
+    variantFile.open(filename);
+    if (!variantFile.is_open()) {
+        return 1;
+    }
+
+    vector<FastaReference*> insertions;
+    if (!insertion_files.empty()){
+        for (auto x : insertion_files){
+            FastaReference* ins = new FastaReference();
+            insertions.push_back(ins);
+            ins->open(x);
+        }
+    }
+
+    FastaReference ref;
+    if(!ref_file.empty()){
+        ref.open(ref_file);
+    }
+
+
+    cout << variantFile.header << endl;
+
+    Variant var;
+    while (variantFile.getNextVariant(var)) {
+        bool valid = var.canonicalize_sv(ref, insertions, max_interval);
+        //bool valid = canonicalize_sv(FastaReference& ref, vector<FastaReference*> insertions, int interval_sz = -1);
+        if (!valid){
+            cerr << "Variant could not be normalized" << var << endl;
+        }
+        cout << var << endl;
+    }
+
+    return 0;
+
+}
+


### PR DESCRIPTION
This adds a script to normalize SVs in a VCF file, given the relevant reference and optionally a fasta file containing insertion sequences.