### PR TITLE
Fix SV len / SV end fields; add proper inversion handling

### DIFF
--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -183,7 +183,7 @@ int64_t Variant::get_sv_len(int pos){
             if (this->info.find("SVLEN") != this->info.end()){
                 int64_t pre_abs = stol(this->info["SVLEN"][pos]); 
                 sv_len = abs(pre_abs);
-                this->info["END"][pos] = this->position + abs(sv_len);
+                this->info["END"][pos] = to_string(this->position + abs(sv_len));
             }
             else if (this->info.find("END") != this->info.end()){
                 int64_t pre_abs = stol(this->info["END"][pos]) - (this->position);
@@ -301,8 +301,6 @@ bool Variant::canonicalize_sv(FastaReference& fasta_reference, vector<FastaRefer
 
 
                         sv_len = get_sv_len(alt_pos);
-                        get_sv_end(alt_pos);
-
 
 
                         /**if (this->info.find("SVLEN") != this->info.end()){

--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -144,6 +144,23 @@ bool Variant::canonicalize_sv(FastaReference& fasta_reference, vector<FastaRefer
     return true;
     };
 
+
+    std::function<string(const string&)> revcomp = [](const string& s){
+
+        int len = s.length();
+        char* ret = new char[len];
+        char rev_arr [26] = {84, 66, 71, 68, 69, 70, 67, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 65,
+                        85, 86, 87, 88, 89, 90};
+
+        for (int i = len - 1; i >=0; i--){
+            ret[ len - 1 - i ] = (char) rev_arr[ (int) s[i] - 65];
+        }
+
+        return string(ret, len);
+        
+
+    };
+
         if (!this->is_sv()){
             return true;
         }
@@ -242,7 +259,7 @@ bool Variant::canonicalize_sv(FastaReference& fasta_reference, vector<FastaRefer
                         else if (a == "<INV>" || this->info["SVTYPE"][alt_pos] == "INV"){
                             this->ref = fasta_reference.getSubSequence(this->sequenceName, this->position, sv_len);
                             string alt_str(fasta_reference.getSubSequence(this->sequenceName, this->position, sv_len));
-                            reverse(alt_str.begin(), alt_str.end());
+                            alt_str = revcomp(alt_str);
                             this->alt[alt_pos] = alt_str;
 
                             // add 3 bases padding to right side 

--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -112,16 +112,122 @@ void Variant::parse(string& line, bool parseSamples) {
     //return true; // we should be catching exceptions...
 }
 
+pair<Variant, Variant> Variant::convert_to_breakends(FastaReference& fasta_reference){
+
+    if (is_sv()){
+        Variant f;
+        Variant s;
+
+        // just copy our old variant to keep our evidence tags and such
+        f = *this;
+        s = *this;
+        // First variant gets our position
+        // The second goes at sv end
+        // We need to modify the ALT field
+        // and the SVTYPE
+        // and the name
+        // and the pair info field, if there
+        
+        int prefix = rand();
+        stringstream f_new_alt;
+        stringstream s_new_alt;
+
+        string f_new_ref;
+        string s_new_ref;
+
+        string f_new_id;
+        string s_new_id;
+
+        int64_t opos = get_sv_end();
+
+
+        f_new_ref = (fasta_reference.getSubSequence(this->sequenceName, this->position, 1));
+        s_new_ref = (fasta_reference.getSubSequence(this->sequenceName, opos, 1));
+
+        if (this->info["SVTYPE"][0] == "DEL"){
+            f_new_alt << f_new_ref << "[" << this->sequenceName << ":" << opos << "[";  
+            s_new_alt << s_new_ref << "]" << this->sequenceName << ":" << opos << "]";
+        }
+        else if (this->info["SVTYPE"][0] == "INS"){
+            f_new_alt << "";
+            s_new_alt <<  "";
+        }
+        else if (this->info["SVTYPE"][0] == "INV"){
+            f_new_alt << "";
+            s_new_alt <<  "";
+        } 
+
+
+
+        return make_pair(f, s);
+    }
+
+    else if (this->info.find("SVTYPE") != this->info.end() &&
+               this->info["SVTYPE"][0] == "TRA"){
+
+    }
+    
+    else{
+        cerr << "ERROR: non-SV types cannot be converted to BND format" << endl;
+        exit(999);
+    }
+};
+
 bool Variant::is_sv(){
     return this->info.find("SVTYPE") != this->info.end();
 }
 
-bool Variant::canonicalize_sv(FastaReference& fasta_reference, vector<FastaReference*> insertions, int max_interval){
+int64_t Variant::get_sv_len(){
+        int64_t sv_len;
+        if (is_sv()){
+            if (this->info.find("SVLEN") != this->info.end()){
+                int64_t pre_abs = stol(this->info["SVLEN"][0]); 
+                sv_len = abs(pre_abs);
+                this->info["END"][0] = this->position + sv_len;
+            }
+            else if (this->info.find("END") != this->info.end()){
+                int64_t pre_abs = stol(this->info["END"][0]) - (this->position);
+                sv_len = abs( pre_abs );
+                this->info["SVLEN"][0] = sv_len;
+
+                }
+                else{
+                    cerr << "NO SV LENGTH INFO" << endl;
+                    exit(1999);
+                }
+
+            return sv_len;
+        }
+        else {
+            cerr << "NOT A STRUCTURAL VARIANT" << endl;
+            exit(1872);
+        }
+}
+
+int64_t Variant::get_sv_end(){
+    if (is_sv()){
+        int64_t slen = get_sv_len();
+        if (this->info["SVTYPE"][0] == "DEL"){
+            return (this->position - slen);
+        }
+        else{
+
+            return (this->position + slen);
+        }
+    }
+    else{
+        cerr << "VARIANT MUST BE SV" << endl;
+        exit(99829);
+    }
+}
+
+bool Variant::canonicalize_sv(FastaReference& fasta_reference, vector<FastaReference*> insertions, bool place_seq, int max_interval){
     
             bool variant_acceptable = true;
             bool do_external_insertions = !insertions.empty();
             int32_t sv_len = 0;
             bool var_is_sv = false;
+
             FastaReference* insertion_fasta;
 
 #ifdef DEBUG
@@ -177,10 +283,12 @@ bool Variant::canonicalize_sv(FastaReference& fasta_reference, vector<FastaRefer
                         if (this->info.find("SVLEN") != this->info.end()){
                             int32_t pre_abs = stoi(this->info["SVLEN"][alt_pos]); 
                             sv_len = abs(pre_abs);
+                            this->info["END"][alt_pos] = this->position + sv_len;
                         }
                         else if (this->info.find("END") != this->info.end()){
                             int32_t pre_abs = stoi(this->info["END"][alt_pos]) - (this->position);
                             sv_len = abs( pre_abs );
+                            this->info["SVLEN"][alt_pos] = sv_len;
 
                         }
                         else{
@@ -189,7 +297,7 @@ bool Variant::canonicalize_sv(FastaReference& fasta_reference, vector<FastaRefer
                             break;
                         }
 
-                        if (this->info["SVTYPE"][alt_pos] == "INS" || a == "<INS>"){
+                        if (place_seq && (this->info["SVTYPE"][alt_pos] == "INS" || a == "<INS>")){
                             this->ref.assign(fasta_reference.getSubSequence(this->sequenceName, this->position, 1));
                             //if (this->alt[alt_pos] == "<INS>"){
                             //    variant_acceptable = false;
@@ -223,7 +331,7 @@ bool Variant::canonicalize_sv(FastaReference& fasta_reference, vector<FastaRefer
                                 variant_acceptable = false;
                             }
                         }
-                        else if (a == "<DEL>" || this->info["SVTYPE"][alt_pos] == "DEL"){
+                        else if (place_seq && (a == "<DEL>" || this->info["SVTYPE"][alt_pos] == "DEL")){
 
 
                             this->ref.assign(fasta_reference.getSubSequence(this->sequenceName, this->position, sv_len + 1 ));
@@ -239,7 +347,7 @@ bool Variant::canonicalize_sv(FastaReference& fasta_reference, vector<FastaRefer
                             this->updateAlleleIndexes();
 
                         }
-                        else if (a == "<INV>" || this->info["SVTYPE"][alt_pos] == "INV"){
+                        else if (place_seq && (a == "<INV>" || this->info["SVTYPE"][alt_pos] == "INV")){
                             this->ref = fasta_reference.getSubSequence(this->sequenceName, this->position, sv_len);
                             string alt_str(fasta_reference.getSubSequence(this->sequenceName, this->position, sv_len));
                             reverse(alt_str.begin(), alt_str.end());

--- a/src/Variant.h
+++ b/src/Variant.h
@@ -221,8 +221,11 @@ public:
 
     // Convert a structural variant the canonical VCF4.2 format using a reference.
     // returns true if the variant is canonicalized, false otherwise.
-    bool canonicalize_sv(FastaReference& ref, vector<FastaReference*> insertions, int interval_sz = -1);
-
+    bool canonicalize_sv(FastaReference& ref, vector<FastaReference*> insertions, bool place_seq = false, int interval_sz = -1);
+    
+    pair<Variant, Variant> convert_to_breakends(FastaReference& ref);
+    int64_t get_sv_end();
+    int64_t get_sv_len();
     bool is_sv();
 
     string originalLine; // the literal of the record, as read

--- a/src/Variant.h
+++ b/src/Variant.h
@@ -224,8 +224,8 @@ public:
     bool canonicalize_sv(FastaReference& ref, vector<FastaReference*> insertions, bool place_seq = false, int interval_sz = -1);
     
     pair<Variant, Variant> convert_to_breakends(FastaReference& ref);
-    int64_t get_sv_end();
-    int64_t get_sv_len();
+    int64_t get_sv_end(int pos);
+    int64_t get_sv_len(int pos);
     bool is_sv();
 
     string originalLine; // the literal of the record, as read

--- a/src/vcfnormalizesvs.cpp
+++ b/src/vcfnormalizesvs.cpp
@@ -10,7 +10,7 @@ void print_help(char** argv){
         << "usage: " << argv[0] << " [OPTIONS] var.vcf" << endl
         << "Options: " << endl
         << "   -r / --reference <ref.fa>   FASTA-format reference genome from which to pull SV sequences." << endl
-        << "   -i / --inserions <ins.fa>   FASTA-format insertion sequences, with IDs matching the ALT allele tags in the vcf" << endl
+        << "   -i / --insertions <ins.fa>   FASTA-format insertion sequences, with IDs matching the ALT allele tags in the vcf" << endl
         << endl;
 }
 
@@ -20,6 +20,7 @@ int main(int argc, char** argv) {
     string ref_file = "";
     vector<string> insertion_files;
     int max_interval = -1;
+    bool replace_sequences = true;
 
     int c = 0;
     while (true) {
@@ -28,16 +29,20 @@ int main(int argc, char** argv) {
                 {"insertions", no_argument, 0, 'i'},
                 {"help", no_argument, 0, 'h'},
                 {"reference", required_argument, 0, 'r'},
+                {"no-replace-sequences", no_argument, 0, 's'},
                 {0, 0, 0, 0}
             };
         int option_index = 0;
 
-        c = getopt_long (argc, argv, "r:i:h",
+        c = getopt_long (argc, argv, "sr:i:h",
                          long_options, &option_index);
         if (c == -1)
             break;
         /* Detect the end of the options. */
         switch(c){
+        case 's':
+            replace_sequences = false;
+            break;
         case 'r':
             ref_file = optarg;
             break;
@@ -87,7 +92,7 @@ int main(int argc, char** argv) {
 
     Variant var;
     while (variantFile.getNextVariant(var)) {
-        bool valid = var.canonicalize_sv(ref, insertions, max_interval);
+        bool valid = var.canonicalize_sv(ref, insertions, replace_sequences, max_interval);
         if (!valid){
             cerr << "Variant could not be normalized" << var << endl;
         }


### PR DESCRIPTION
Inversions weren't reverse complemented, which threw off things downstream in vg. The SV len / SV end fields were also mishandled. They seem to work ok on OS X but there might be an overflow issue on linux.