### PR TITLE
Added lib lzma and bzip2 linking flags.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ FSOM = fsom/fsom.o
 FILEVERCMP = filevercmp/filevercmp.o
 
 INCLUDES = -Itabixpp/htslib -I$(INC_DIR) -L. -Ltabixpp/htslib
-LDFLAGS = -L$(LIB_DIR) -lvcflib -lhts -lpthread -lz -lm
+LDFLAGS = -L$(LIB_DIR) -lvcflib -lhts -lpthread -lz -lm -llzma -lbz2
 
 
 all: $(OBJECTS) $(BINS) scriptToBin


### PR DESCRIPTION
In order for `vcflib` to fully compile, the `tabixpp` [PR](https://github.com/ekg/tabixpp/pull/15) needs to be merged. See #204 for a quick fix in the mean time.