### PR TITLE
Fix missing newlines in multi-variant TSV outputs

### DIFF
--- a/src/vcf2tsv.cpp
+++ b/src/vcf2tsv.cpp
@@ -86,7 +86,7 @@ void loadInfoSS(std::stringstream & ss,
             loadGenoSS(ss, o, var, vcf, nullval, formatfields);
         }
         else{
-            ss << o.str() ;
+            ss << o.str() << std::endl;
         }
     }
 }
@@ -202,12 +202,7 @@ int main(int argc, char** argv) {
 
         loadInfoSS(outputRecord, keepFields, var, variantFile, nullval, formatfields, genotypes);
 
-        if(!genotypes){
-            std::cout << outputRecord.str() << std::endl;
-        }
-        else{
-            std::cout << outputRecord.str() ;
-        }
+        std::cout << outputRecord.str() ;
 
     }
     return 0;


### PR DESCRIPTION
As discussed in issue #206, it seems like for some inputs loadInfoSS() writes multiple entries
to the output stringstream, without appending a newline. Fixing this allows to remove the special
case handling of the newline in main() for all I can see.

Signed-off-by: Kai Blin <kblin@biosustain.dtu.dk>