### PR TITLE
Fix build within vg build system

### DIFF
--- a/src/abba-baba.cpp
+++ b/src/abba-baba.cpp
@@ -71,6 +71,7 @@ random sampling adds noise but will not affect the overall measurement
 of D-statistic */
 int  sample_het(int &rv){
   rv = rand() % 2 ; // pick from 0/1 het with 50-50 odds
+  return rv;
 }
 
 


### PR DESCRIPTION
In my hands, I can't build current master under `vg`'s build system, even if I tell the driving Makefile to just `make` instead of `make libvcflib.a`. It's because a couple of places (one in vcflib itself and one in fastahack) are missing return statements.

This PR fixes the missing return in vcflib and updates to a fixed fastahack.