### PR TITLE
Use new htslib and allow configuring with libdeflate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,7 @@ add_dependencies(htslib htslib-build)
 # that, pass -DHTSLIB_EXTRA_LIBS="-ldeflate" when configuring the project with
 # cmake.
 # TODO: Stop vendoring in htslib and just use find_package
+set(HTSLIB_EXTRA_LIBS "-lcurl" CACHE STRING "Library flags needed to link with htslib's dependencies, for chosen configuration")
 set_property(TARGET htslib PROPERTY INTERFACE_LINK_LIBRARIES ${HTSLIB_EXTRA_LIBS})
 
 add_definitions(-DVERSION="${GIT_VERSION}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,11 @@ add_library(htslib STATIC IMPORTED)
 set_property(TARGET htslib PROPERTY 
   IMPORTED_LOCATION ${CMAKE_SOURCE_DIR}/tabixpp/htslib/libhts.a)
 add_dependencies(htslib htslib-build)
+# If the user wants to configure our HTSlib to build with libddeflate, we need
+# to make sure to link against libdeflate as a transitive dependency. To do
+# that, pass -DHTSLIB_EXTRA_LIBS="-ldeflate" when configuring the project with
+# cmake.
+set_property(TARGET htslib PROPERTY INTERFACE_LINK_LIBRARIES ${HTSLIB_EXTRA_LIBS})
 
 add_definitions(-DVERSION="${GIT_VERSION}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,7 @@ add_dependencies(htslib htslib-build)
 # to make sure to link against libdeflate as a transitive dependency. To do
 # that, pass -DHTSLIB_EXTRA_LIBS="-ldeflate" when configuring the project with
 # cmake.
+# TODO: Stop vendoring in htslib and just use find_package
 set_property(TARGET htslib PROPERTY INTERFACE_LINK_LIBRARIES ${HTSLIB_EXTRA_LIBS})
 
 add_definitions(-DVERSION="${GIT_VERSION}")


### PR DESCRIPTION
I want to use the htslib provided by vcflib as the one true htslib in the vg build.

The vg build wants to build its htslib against libdeflate, but the external project cmake config for building htslib doesn't read htslib's pkg-config files, and really has no way of knowing if htslib has been configured to need a "-ldeflate" or not.

I've added a CMake variable (`HTSLIB_EXTRA_LIBS`) where you can stuff `-ldeflate` to get vcflib to link properly when you pre-configure and pre-build the bundled htslib with libdeflate support.

In general I'm not sure why vcflib needs to package htslib; it's available in many distros now, and vcflib doesn't seem to itself need any particular version. The new CMake build system should be quite able to find it via CMake's pkg-config support, if it is installed at the system level. Then vg could induce vcflib to build against vg's bundled htslib by setting up PKG_CONFIG_PATH, which it already does.