### PR TITLE
when I use vcfnulldotslashdot in my server, it shows error

### DIFF
--- a/scripts/vcfnulldotslashdot
+++ b/scripts/vcfnulldotslashdot
@@ -15,7 +15,7 @@ for line in sys.stdin:
     alleles = len(fields[4].split(","))+1
     # assume that we have GT:GL
     # how many genotypes?  assume diploid
-    flatgls = ",".join([str(x) for x in [0]*multcoeff(alleles,2)])
+    flatgls = ",".join([str(x) for x in [0]*int(multcoeff(alleles,2))])
     for i in range(9, len(fields)):
         if fields[i] == ".":
             fields[i] = "./.:" + flatgls


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "../vcfnulldotslashdot", line 17, in <module>
    flatgls = ",".join([str(x) for x in [0]*multcoeff(alleles,2)])
TypeError: can't multiply sequence by non-int of type 'float'
```

So, I add an int() to multcoeff in line 18 in this file, because it's type 'float'.
I don't know if there is correct.
If my modification is wrong, I hope you can tell me!
Thanks!