### PR TITLE
vcfflatten: fix segfault when no 'AF' field is present (#47).

### DIFF
--- a/man/vcfflatten.1
+++ b/man/vcfflatten.1
@@ -7,7 +7,7 @@
 \f[B]vcfflatten\f[R]
 .SH SYNOPSIS
 .PP
-\f[B]vcfflatten\f[R] [file]
+\f[B]vcfflatten\f[R] [options] [\fIfile\fR]
 .SH DESCRIPTION
 .PP
 Removes multi-allelic sites by picking the most common alternate.
@@ -18,9 +18,13 @@ VCF file may be specified on the command line or piped as stdin.
 .IP
 .nf
 \f[C]
-
-
-Type: transformation
+.IP "\fB\-h, --help\fR"
+.IX Item "-h, --help"
+display this help message and exit.
+.IP "\fB\-i, --ignore-errors\fR"
+.IX Item "-i, --ignore-errors"
+do not try to flatten a line if it does not contain an 'AF' field.
+.IP "\fB\Type:\fR \fItransformation\fR"
 \f[R]
 .fi
 .SH EXIT VALUES

--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -88,7 +88,6 @@ bool allATGCN(const string& s, bool allowLowerCase){
 
 
 void Variant::parse(string& line, bool parseSamples) {
-
     // clean up potentially variable data structures
     info.clear();
     infoFlags.clear();
@@ -2315,7 +2314,6 @@ map<pair<int, int>, int> Variant::getGenotypeIndexesDiploid(void) {
         genotypeIndexes[make_pair(j, k)] = (k * (k + 1) / 2) + j;
     }
     return genotypeIndexes;
-
 }
 
 void Variant::updateAlleleIndexes(void) {

--- a/src/Variant.h
+++ b/src/Variant.h
@@ -142,7 +142,13 @@ public:
         return parsedHeader;
     }
 
-VariantCallFile(void) : usingTabix(false), parseSamples(true), justSetRegion(false), parsedHeader(false) { }
+    VariantCallFile(void) :
+        usingTabix(false),
+        parseSamples(true),
+        justSetRegion(false),
+        parsedHeader(false)
+    { }
+
     ~VariantCallFile(void) {
         if (usingTabix) {
             delete tabixFile;
@@ -213,7 +219,7 @@ public:
     vector<string> alt;      // a list of all the alternate alleles present at this locus
     vector<string> alleles;  // a list all alleles (ref + alt) at this locus
                              // the indicies are organized such that the genotype codes (0,1,2,.etc.)
-                             // correspond to the correct offest into the allelese vector.
+                             // correspond to the correct offest into the alleles vector.
                              // that is, alleles[0] = ref, alleles[1] = first alternate allele, etc.
 
     string vrepr(void);  // a comparable record of the variantion described by the record


### PR DESCRIPTION
vcfflatten crashed when flattening a VCF file with more than 2 alleles for a locus if no 'AF' field was present.

here are the offending lines:
```
#vcfflaten.cpp l.122

            vector<double>::iterator f = freqs.begin();   
            for (vector<string>::iterator a = var.alt.begin(); a != var.alt.end(); ++a, ++f) {   
                alleleFrequencies.insert(pair<double, string>(*f, *a));    
            }     
```
With no 'AF' field, we ended up with an empty freqs vector. Some pointer arithmetic then incremented the pointer f, which was finally dereferenced to an illegal value.

To solve this, I propose to terminate the program when a line with more than 2 alleles for a locus is encountered if it has no 'AF' field.
However, we can add the --best-effort option. If it is passed as an argument to the program alongside a filename, then we output the offending line without modifying it.