### PR TITLE
Fix/issue 251

### DIFF
--- a/src/hapLrt.cpp
+++ b/src/hapLrt.cpp
@@ -407,14 +407,13 @@ int main(int argc, char** argv) {
     okayGenotypeLikelihoods["GP"] = 1;
     okayGenotypeLikelihoods["GT"] = 1;
 
-
     if(type == "NA"){
-      cerr << "FATAL: failed to specify genotype likelihood format : PL or GL" << endl;
+      cerr << "FATAL: failed to specify genotype likelihood format : PL, GL or GP" << endl;
       printHelp();
       return 1;
     }
     if(okayGenotypeLikelihoods.find(type) == okayGenotypeLikelihoods.end()){
-      cerr << "FATAL: genotype likelihood is incorrectly formatted, only use: PL or GL" << endl;
+      cerr << "FATAL: genotype likelihood is incorrectly formatted, only use: PL, GL or GP" << endl;
       printHelp();
       return 1;
     }

--- a/src/hapLrt.cpp
+++ b/src/hapLrt.cpp
@@ -544,6 +544,21 @@ int main(int argc, char** argv) {
       for(int nsamp = 0; nsamp < nsamples; nsamp++){
         map<string, vector<string> > sample = var.samples[samples[nsamp]];
 
+        /* Accessing to a key not defined in a map creates a default constructed
+         * value for this key.
+         * Thus, checking for key: 'type' in samples creates a default value for
+         * it if it does not exist, which changes the output of the program from
+         * -nan to very small decimal values when reading it in
+         * genotype::loadPop().
+         * We have to check from var.samples instead to make sure not to change
+         * the behavior of the program.
+         */
+        if(!var.samples[samples[nsamp]][type].size())
+        {
+          cerr << "Bad file format: genotype field " << type << " is not present for: " << var.sequenceName << " " << var.position << endl;
+          exit(1);
+        }
+
         if(targetIndex.find(sindex) != targetIndex.end() ){
           target.push_back(sample);
           total.push_back(sample);

--- a/src/hapLrt.cpp
+++ b/src/hapLrt.cpp
@@ -48,11 +48,11 @@ void printHelp(void){
   cerr << "INFO: Usage: hapLRT  --target 0,1,2,3,4,5,6,7 --background 11,12,13,16,17,19,22 --type GP --file my.vcf                                     " << endl;
   cerr << endl;
 
-  cerr << "INFO: required: t,target     -- argument: a zero base comma separated list of target individuals corrisponding to VCF columns        " << endl;
-  cerr << "INFO: required: b,background -- argument: a zero base comma separated list of background individuals corrisponding to VCF columns    " << endl;
+  cerr << "INFO: required: t,target     -- argument: a zero base comma separated list of target individuals corresponding to VCF columns        " << endl;
+  cerr << "INFO: required: b,background -- argument: a zero base comma separated list of background individuals corresponding to VCF columns    " << endl;
   cerr << "INFO: required: f,file       -- argument: a properly formatted phased VCF file                                                       " << endl;
   cerr << "INFO: required: y,type       -- argument: type of genotype likelihood: PL, GL or GP                                                  " << endl;
-  cerr << "INFO: optional: r,region     -- argument: a genomice range to calculate hapLrt on in the format : \"seqid:start-end\" or \"seqid\" " << endl;
+  cerr << "INFO: optional: r,region     -- argument: a genomic range to calculate hapLrt on in the format : \"seqid:start-end\" or \"seqid\" " << endl;
   cerr << endl;
   cerr << endl << "Type: genotype" << endl << endl;
 

--- a/src/hapLrt.cpp
+++ b/src/hapLrt.cpp
@@ -350,56 +350,56 @@ int main(int argc, char** argv) {
   string type = "NA";
 
     const struct option longopts[] =
-      {
-	{"version"   , 0, 0, 'v'},
-	{"help"      , 0, 0, 'h'},
-        {"file"      , 1, 0, 'f'},
-	{"target"    , 1, 0, 't'},
-	{"background", 1, 0, 'b'},
-	{"region"    , 1, 0, 'r'},
-	{"type"      , 1, 0, 'y'},
+    {
+      {"version"   , 0, 0, 'v'},
+      {"help"      , 0, 0, 'h'},
+      {"file"      , 1, 0, 'f'},
+      {"target"    , 1, 0, 't'},
+      {"background", 1, 0, 'b'},
+      {"region"    , 1, 0, 'r'},
+      {"type"      , 1, 0, 'y'},
 
-	{0,0,0,0}
-      };
+      {0,0,0,0}
+    };
 
     int findex;
     int iarg=0;
 
     while(iarg != -1)
-      {
-	iarg = getopt_long(argc, argv, "y:r:t:b:f:hv", longopts, &findex);
+    {
+      iarg = getopt_long(argc, argv, "y:r:t:b:f:hv", longopts, &findex);
 
-	switch (iarg)
-	  {
-	  case 'h':
-	    printHelp();
-	  case 'v':
-	    printVersion();
-	  case 'y':
-	    type = optarg;
-	    break;
-	  case 't':
-	    loadIndices(targetIndex, optarg);
-	    cerr << "INFO: there are " << targetIndex.size() << " individuals in the target" << endl;
-	    cerr << "INFO: target ids: " << optarg << endl;
-	    break;
-	  case 'b':
-	    loadIndices(backgroundIndex, optarg);
-	    cerr << "INFO: there are " << backgroundIndex.size() << " individuals in the background" << endl;
-	    cerr << "INFO: background ids: " << optarg << endl;
-	    break;
-	  case 'f':
-	    cerr << "INFO: file: " << optarg  <<  endl;
-	    filename = optarg;
-	    break;
-	  case 'r':
-            cerr << "INFO: set seqid region to : " << optarg << endl;
-	    region = optarg;
-	    break;
-	  default:
-	    break;
-	  }
+      switch (iarg)
+      {
+        case 'h':
+          printHelp();
+        case 'v':
+          printVersion();
+        case 'y':
+          type = optarg;
+          break;
+        case 't':
+          loadIndices(targetIndex, optarg);
+          cerr << "INFO: there are " << targetIndex.size() << " individuals in the target" << endl;
+          cerr << "INFO: target ids: " << optarg << endl;
+          break;
+        case 'b':
+          loadIndices(backgroundIndex, optarg);
+          cerr << "INFO: there are " << backgroundIndex.size() << " individuals in the background" << endl;
+          cerr << "INFO: background ids: " << optarg << endl;
+          break;
+        case 'f':
+          cerr << "INFO: file: " << optarg  <<  endl;
+          filename = optarg;
+          break;
+        case 'r':
+          cerr << "INFO: set seqid region to : " << optarg << endl;
+          region = optarg;
+          break;
+        default:
+          break;
       }
+    }
 
     map<string, int> okayGenotypeLikelihoods;
     okayGenotypeLikelihoods["PL"] = 1;
@@ -471,7 +471,6 @@ int main(int argc, char** argv) {
     }
 
 
-
     Variant var(variantFile);
 
     vector<string> samples = variantFile.sampleNames;
@@ -483,17 +482,17 @@ int main(int argc, char** argv) {
 
     for(vector<string>::iterator samp = samples.begin(); samp != samples.end(); samp++){
 
-      string samplename  = (*samp) ;
+      string samplename  = (*samp);
 
-      if(targetIndex.find(index) != targetIndex.end() ){
+      if(targetIndex.find(index) != targetIndex.end()){
         iti.push_back(indexi);
-	//	itot.push_back(indexi);
-	indexi++;
+        //	itot.push_back(indexi);
+        indexi++;
       }
       if(backgroundIndex.find(index) != backgroundIndex.end()){
         ibi.push_back(indexi);
-	//	itot.push_back(indexi);
-	indexi++;
+        //	itot.push_back(indexi);
+        indexi++;
       }
       index++;
     }
@@ -507,36 +506,35 @@ int main(int argc, char** argv) {
     vector<double>   afs;
 
     //string haplotypes [nsamples][2];
-	string **haplotypes = new string*[nsamples];
-	for (int i = 0; i < nsamples; i++) {
-	  haplotypes[i] = new string[2];
-	}
+    string **haplotypes = new string*[nsamples];
+    for (int i = 0; i < nsamples; i++) {
+      haplotypes[i] = new string[2];
+    }
 
     string currentSeqid = "NA";
 
     int count = 0;
     while (variantFile.getNextVariant(var)) {
       count++;
-      //cerr << count << endl;
 
       if(!var.isPhased()){
-	cerr <<"FATAL: Found an unphased variant. All genotypes must be phased!" << endl;
-	printHelp();
-	return(1);
+        cerr <<"FATAL: Found an unphased variant. All genotypes must be phased!" << endl;
+        printHelp();
+        return(1);
       }
 
-      if(var.alt.size() > 1){
-	continue;
+      if (var.alt.size() > 1){
+        continue;
       }
 
       if(currentSeqid != var.sequenceName){
-	if(haplotypes[0][0].length() > 10){
-	  calc(haplotypes, nsamples, positions, afs, iti, ibi, itot, currentSeqid);
-	}
-	clearHaplotypes(haplotypes, nsamples);
-	positions.clear();
-	currentSeqid = var.sequenceName;
-	afs.clear();
+        if(haplotypes[0][0].length() > 10){
+          calc(haplotypes, nsamples, positions, afs, iti, ibi, itot, currentSeqid);
+        }
+        clearHaplotypes(haplotypes, nsamples);
+        positions.clear();
+        currentSeqid = var.sequenceName;
+        afs.clear();
       }
 
       vector < map< string, vector<string> > > target, background, total;
@@ -544,26 +542,25 @@ int main(int argc, char** argv) {
       int sindex = 0;
 
       for(int nsamp = 0; nsamp < nsamples; nsamp++){
+        map<string, vector<string> > sample = var.samples[samples[nsamp]];
 
-	map<string, vector<string> > sample = var.samples[ samples[nsamp]];
+        if(targetIndex.find(sindex) != targetIndex.end() ){
+          target.push_back(sample);
+          total.push_back(sample);
+        }
+        if(backgroundIndex.find(sindex) != backgroundIndex.end()){
+          background.push_back(sample);
+          total.push_back(sample);
+        }
 
-	if(targetIndex.find(sindex) != targetIndex.end() ){
-	  target.push_back(sample);
-	  total.push_back(sample);
-	}
-	if(backgroundIndex.find(sindex) != backgroundIndex.end()){
-	  background.push_back(sample);
-	  total.push_back(sample);
-	}
-
-	sindex += 1;
+        sindex += 1;
       }
 
       using Detail::makeUnique;
 
-      unique_ptr<genotype> populationTarget    ;
+      unique_ptr<genotype> populationTarget;
       unique_ptr<genotype> populationBackground;
-      unique_ptr<genotype> populationTotal     ;
+      unique_ptr<genotype> populationTotal;
 
       if (type == "PL"){
         populationTarget     = makeUnique<pl>();
@@ -591,23 +588,12 @@ int main(int argc, char** argv) {
 
 
       if(populationTotal->af > 0.95 || populationTotal->af < 0.05){
-	;
-	;	
-	
-	continue;
+        continue;
       }
 
-
-
-	afs.push_back(populationTotal->af);
-	positions.push_back(var.position);
-	loadPhased(haplotypes, populationTotal.get(), nsamples);
-
-	;
-	;	
-	
-
-
+      afs.push_back(populationTotal->af);
+      positions.push_back(var.position);
+      loadPhased(haplotypes, populationTotal.get(), nsamples);
     }  
 
     calc(haplotypes, nsamples, positions, afs, iti, ibi, itot, currentSeqid);

--- a/src/hapLrt.cpp
+++ b/src/hapLrt.cpp
@@ -566,27 +566,23 @@ int main(int argc, char** argv) {
       unique_ptr<genotype> populationBackground;
       unique_ptr<genotype> populationTotal     ;
 
-      if(type == "PL"){
-	populationTarget     = makeUnique<pl>();
-	populationBackground = makeUnique<pl>();
-	populationTotal      = makeUnique<pl>();
-      }
-      if(type == "GL"){
-	populationTarget     = makeUnique<gl>();
-	populationBackground = makeUnique<gl>();
-	populationTotal      = makeUnique<gl>();
-      }
-      if(type == "GP"){
-	populationTarget     = makeUnique<gp>();
-	populationBackground = makeUnique<gp>();
-	populationTotal      = makeUnique<gp>();
-      }
-      if(type == "GT"){
+      if (type == "PL"){
+        populationTarget     = makeUnique<pl>();
+        populationBackground = makeUnique<pl>();
+        populationTotal      = makeUnique<pl>();
+      } else if (type == "GL"){
+        populationTarget     = makeUnique<gl>();
+        populationBackground = makeUnique<gl>();
+        populationTotal      = makeUnique<gl>();
+      } else if (type == "GP"){
+        populationTarget     = makeUnique<gp>();
+        populationBackground = makeUnique<gp>();
+        populationTotal      = makeUnique<gp>();
+      } else if (type == "GT"){
         populationTarget     = makeUnique<gt>();
-	populationBackground = makeUnique<gt>();
+        populationBackground = makeUnique<gt>();
         populationTotal      = makeUnique<gt>();
       }
-
 
       populationTarget->loadPop(target,         var.sequenceName, var.position);
 

--- a/src/var.hpp
+++ b/src/var.hpp
@@ -59,7 +59,7 @@ public:
   double hfrq ;
   
   vector<int> genoIndex;
-  vector<string> gts ;
+  vector<string> gts;
   vector< vector < double > > genoLikelihoods;
   vector< vector < double > > genoLikelihoodsCDF;
 


### PR DESCRIPTION
This partially solves https://github.com/vcflib/vcflib/issues/251
The command `hapLrt --target 1,2 --background 266,267 --type GP --file phasedRename.vcf.txt` results in a sefgfault because there is no GP field in the file.
It then crashed in the `gp::unphred` method since the vector was empty.

To avoid that, we could check if the field exists while creating the _target_ vector.

However, it seems there is another bug when using `--target PL`. It does exist in the file, but it crashes anyway. I'm not sure why..

I also took the opportunity to do some indent, and update the error strings. 