### PR TITLE
Fix/incomplete genotype field

### DIFF
--- a/src/hapLrt.cpp
+++ b/src/hapLrt.cpp
@@ -338,7 +338,7 @@ int main(int argc, char** argv) {
 
   VariantCallFile variantFile;
 
-  // zero based index for the target and background indivudals
+  // zero based index for the target and background individuals
 
   map<int, int> targetIndex, backgroundIndex;
 
@@ -481,7 +481,7 @@ int main(int argc, char** argv) {
 
     vector<int> ibi, iti, itot;
 
-    int index, indexi = 0;
+    int index = 0, indexi = 0;
 
     for(vector<string>::iterator samp = samples.begin(); samp != samples.end(); samp++){
 

--- a/src/hapLrt.cpp
+++ b/src/hapLrt.cpp
@@ -559,6 +559,14 @@ int main(int argc, char** argv) {
           exit(1);
         }
 
+        if((type == "GL" || type == "GP" || type == "PL") && sample[type].size() != 3)
+        {
+          cerr << "Bad file format: genotype field " << type << " should have 3 values but has only ";
+          cerr << sample[type].size() << " for: " << var.sequenceName << " " << var.position;
+          cerr << " in sample " << nsamp << endl;
+          exit(1);
+        }
+
         if(targetIndex.find(sindex) != targetIndex.end() ){
           target.push_back(sample);
           total.push_back(sample);

--- a/src/hapLrt.cpp
+++ b/src/hapLrt.cpp
@@ -548,16 +548,7 @@ int main(int argc, char** argv) {
       for(int nsamp = 0; nsamp < nsamples; nsamp++){
         map<string, vector<string> > sample = var.samples[samples[nsamp]];
 
-        /* Accessing to a key not defined in a map creates a default constructed
-         * value for this key.
-         * Thus, checking for key: 'type' in samples creates a default value for
-         * it if it does not exist, which changes the output of the program from
-         * -nan to very small decimal values when reading it in
-         * genotype::loadPop().
-         * We have to check from var.samples instead to make sure not to change
-         * the behavior of the program.
-         */
-        if(!var.samples[samples[nsamp]][type].size())
+        if(!sample[type].size())
         {
           cerr << "Bad file format: genotype field " << type << " is not present for: " << var.sequenceName << " " << var.position << endl;
           exit(1);

--- a/src/hapLrt.cpp
+++ b/src/hapLrt.cpp
@@ -22,6 +22,7 @@
 #include <time.h>
 #include <stdio.h>
 #include <getopt.h>
+#include <limits.h>
 
 using namespace std;
 using namespace vcflib;
@@ -166,6 +167,8 @@ void findLengths(string **haplotypes, vector<int> group, int core, int lengths[]
 
 double mean(int data[], int n){
 
+  if(!n)
+    return -std::numeric_limits<double>::quiet_NaN();
   int sum;
 
   for(int i = 0; i < n; i++){

--- a/src/hapLrt.cpp
+++ b/src/hapLrt.cpp
@@ -51,7 +51,7 @@ void printHelp(void){
   cerr << "INFO: required: t,target     -- argument: a zero base comma separated list of target individuals corresponding to VCF columns        " << endl;
   cerr << "INFO: required: b,background -- argument: a zero base comma separated list of background individuals corresponding to VCF columns    " << endl;
   cerr << "INFO: required: f,file       -- argument: a properly formatted phased VCF file                                                       " << endl;
-  cerr << "INFO: required: y,type       -- argument: type of genotype likelihood: PL, GL or GP                                                  " << endl;
+  cerr << "INFO: required: y,type       -- argument: type of genotype likelihood: PL, GL, GT or GP                                                  " << endl;
   cerr << "INFO: optional: r,region     -- argument: a genomic range to calculate hapLrt on in the format : \"seqid:start-end\" or \"seqid\" " << endl;
   cerr << endl;
   cerr << endl << "Type: genotype" << endl << endl;
@@ -408,12 +408,12 @@ int main(int argc, char** argv) {
     okayGenotypeLikelihoods["GT"] = 1;
 
     if(type == "NA"){
-      cerr << "FATAL: failed to specify genotype likelihood format : PL, GL or GP" << endl;
+      cerr << "FATAL: failed to specify genotype likelihood format : PL, GL, GT or GP" << endl;
       printHelp();
       return 1;
     }
     if(okayGenotypeLikelihoods.find(type) == okayGenotypeLikelihoods.end()){
-      cerr << "FATAL: genotype likelihood is incorrectly formatted, only use: PL, GL or GP" << endl;
+      cerr << "FATAL: genotype likelihood is incorrectly formatted, only use: PL, GL GT or GP" << endl;
       printHelp();
       return 1;
     }

--- a/src/hapLrt.cpp
+++ b/src/hapLrt.cpp
@@ -169,7 +169,8 @@ double mean(int data[], int n){
 
   if(!n)
     return -std::numeric_limits<double>::quiet_NaN();
-  int sum;
+
+  int sum = 0;
 
   for(int i = 0; i < n; i++){
     sum += data[i];


### PR DESCRIPTION
This should completely solve issue #251.

From my understanding of vcf, the GP, PL and GL fields are expected to have three values.
hapLrt makes this assumption, but when one is missing for a sample, then it segfaults in the unphred methods.

Output before pr:
```
~ hapLrt --target 1,2 --background 266,267 --type PL --file ../phasedRename.vcf.txt.save 
INFO: there are 2 individuals in the target
INFO: target ids: 1,2
INFO: there are 2 individuals in the background
INFO: background ids: 266,267
INFO: file: ../phasedRename.vcf.txt.save
Segmentation fault (core dumped)
```

Output after:
```
~ hapLrt --target 1,2 --background 266,267 --type PL --file ../phasedRename.vcf.txt.save 
INFO: there are 2 individuals in the target
INFO: target ids: 1,2
INFO: there are 2 individuals in the background
INFO: background ids: 266,267
INFO: file: ../phasedRename.vcf.txt.save
Bad file format: genotype field PL should have 3 values but has only 1 for: Pf3D7_01_v3 93293 in sample 42

```

This pr also changes the following
  - sum was not intialized in the mean function,
  - A division by zero was possible in the mean function (we now return -nan to be consistent with previous behavior)
  - index was not intialized in the main function.

This actually changes the output of the program:

output before this pr:
```
~ hapLrt --target 1,2 --background 266,267 --type PL --file ../phasedRename.vcf.txt
INFO: there are 2 individuals in the target
INFO: target ids: 1,2
INFO: there are 2 individuals in the background
INFO: background ids: 266,267
INFO: file: ../phasedRename.vcf.txt
Pf3D7_01_v3     100608  -nan    -nan    1       1
Pf3D7_01_v3     107626  -nan    -nan    1       1
Pf3D7_01_v3     107823  -nan    -nan    1       1
Pf3D7_01_v3     108002  -nan    -nan    1       1
Pf3D7_01_v3     114473  -nan    -nan    1       1
Pf3D7_01_v3     117064  -nan    -nan    1       1
Pf3D7_01_v3     117927  -nan    -nan    1       1
```

output with this pr:
```
~ hapLrt --target 1,2 --background 266,267 --type PL --file ../phasedRename.vcf.txt     
INFO: there are 2 individuals in the target
INFO: target ids: 1,2
INFO: there are 2 individuals in the background
INFO: background ids: 266,267
INFO: file: ../phasedRename.vcf.txt
Pf3D7_01_v3     100608  4.25    7       0.78157 -1
Pf3D7_01_v3     107626  4.25    7       0.78157 -1
Pf3D7_01_v3     107823  3.75    7       0.681537        -1
Pf3D7_01_v3     108002  3.75    7       0.681537        -1
Pf3D7_01_v3     114473  4       7       0.734058        -1
Pf3D7_01_v3     117064  5       7       0.893433        -1
Pf3D7_01_v3     117927  5       7       0.893433        -1
```

I have not yet checked if the values are correct.
You can try it with [the sample file I am using](https://github.com/vcflib/vcflib/files/7919267/phasedRename.vcf.txt) ( a smaller version of the file of the original issue: https://github.com/vcflib/vcflib/issues/251)

I think this requires a careful review since it changes the output of the program.

I apologize this is all done in a same pull request, but I believe all those changes together are required for the bug to be fixed.
Let me know if you still want them to be split in multiple pr.

