### PR TITLE
Fix/fix uninitialized indexes

### DIFF
--- a/src/gl-XPEHH.cpp
+++ b/src/gl-XPEHH.cpp
@@ -569,7 +569,7 @@ int main(int argc, char** argv) {
     vector<string> samples = variantFile.sampleNames;
     vector<int>    target_h, background_h;
 
-    int index, indexi = 0;
+    int index = 0, indexi = 0;
 
     cerr << "INFO: there are " << samples.size() << " individuals in the VCF" << endl;
 

--- a/src/sequenceDiversity.cpp
+++ b/src/sequenceDiversity.cpp
@@ -354,7 +354,7 @@ int main(int argc, char** argv) {
 
     vector<int> target_h, background_h;
 
-    int index, indexi = 0;
+    int index = 0, indexi = 0;
 
     for(vector<string>::iterator samp = samples.begin(); samp != samples.end(); samp++){
       string sampleName = (*samp);

--- a/src/vcfld.cpp
+++ b/src/vcfld.cpp
@@ -322,7 +322,7 @@ int main(int argc, char** argv) {
 
     vector<int> target_h, background_h;
 
-    int index, indexi = 0;
+    int index = 0, indexi = 0;
 
     for(vector<string>::iterator samp = samples.begin(); samp != samples.end(); samp++){
 

--- a/src/xpEHH.cpp
+++ b/src/xpEHH.cpp
@@ -332,7 +332,7 @@ int main(int argc, char** argv) {
 
     vector<int> target_h, background_h;
 
-    int index, indexi = 0;
+    int index = 0, indexi = 0;
 
     for(vector<string>::iterator samp = samples.begin(); samp != samples.end(); samp++){
 


### PR DESCRIPTION
Fix a few unitialized variables.
In C++, each variable must be explicitly initialized to 0. index was left uninitialized.