### PR TITLE
vcfrandomsample: initialize variable when calculating sum.

### DIFF
--- a/src/vcfrandomsample.cpp
+++ b/src/vcfrandomsample.cpp
@@ -156,7 +156,7 @@ int main(int argc, char** argv) {
         double randN = genrand_real1();
         if (!scaleByKey.empty()) {
             if (var.info.find(scaleByKey) != var.info.end()) {
-                double val;
+                double val = 0;
 
                 // hack, sum the values of interest if we have multiple values
                 // really, this is only suitable for AF stuff


### PR DESCRIPTION
Since the sum was not initialized, the behaviour of the program was undefined.
For example, while scaling allele frequency, the program often terminated early since the value often exceeded one.

Before initialization, the command `vcfrandomsample -s AF phasedRename.vcf.txt` (file attached) terminated with the error message `cannot scale by AF=1.582 as it is > 1`.

After initialization, it finishes fine.

[phasedRename.vcf.txt](https://github.com/vcflib/vcflib/files/7953710/phasedRename.vcf.txt)