### PR TITLE
Variant: pass const references to ctor.

### DIFF
--- a/src/Variant.h
+++ b/src/Variant.h
@@ -196,7 +196,7 @@ public:
     bool isDeletion(void);
     bool isIndel(void);
     */
-    VariantAllele(string r, string a, long p)
+    VariantAllele(string const & r, string const & a, long p)
         : ref(r), alt(a), position(p)
     {
         stringstream s;


### PR DESCRIPTION
using references avoids unnecessary copies of the arguments.