### PR TITLE
Remove unused variable

### DIFF
--- a/src/genotypeSummary.cpp
+++ b/src/genotypeSummary.cpp
@@ -345,7 +345,7 @@ int main(int argc, char** argv) {
     populationTarget     = makeUnique<gt>();
 	}
 
-	populationTarget->loadPop(target, var.sequenceName, var.position);
+	populationTarget->loadPop(target, var.position);
 
 	for(int i = 0; i < populationTarget->genoIndex.size() ; i++){
 	  if(populationTarget->genoIndex[i] == -1){

--- a/src/hapLrt.cpp
+++ b/src/hapLrt.cpp
@@ -598,11 +598,11 @@ int main(int argc, char** argv) {
         populationTotal      = makeUnique<gt>();
       }
 
-      populationTarget->loadPop(target,         var.sequenceName, var.position);
+      populationTarget->loadPop(target,         var.position);
 
-      populationBackground->loadPop(background, var.sequenceName, var.position);
+      populationBackground->loadPop(background, var.position);
 
-      populationTotal->loadPop(total,           var.sequenceName, var.position);
+      populationTotal->loadPop(total,           var.position);
 
 
       if(populationTotal->af > 0.95 || populationTotal->af < 0.05){

--- a/src/iHS.cpp
+++ b/src/iHS.cpp
@@ -636,7 +636,7 @@ int main(int argc, char** argv) {
 	populationTarget     = makeUnique<gt>();
       }
 
-      populationTarget->loadPop(target, var.sequenceName, var.position);
+      populationTarget->loadPop(target, var.position);
 
       if(populationTarget->af <= globalOpts.af
 	 || populationTarget->nref < 2

--- a/src/meltEHH.cpp
+++ b/src/meltEHH.cpp
@@ -624,7 +624,7 @@ int main(int argc, char** argv) {
 	populationTarget     = makeUnique<gt>();
       }
 
-      populationTarget->loadPop(target, var.sequenceName, var.position);
+      populationTarget->loadPop(target, var.position);
 
       if(populationTarget->af <= globalOpts.af
 	 || populationTarget->nref < 2

--- a/src/pFst.cpp
+++ b/src/pFst.cpp
@@ -306,9 +306,9 @@ int main(int argc, char** argv) {
           populationTotal      = makeUnique<gt>();
         }
 
-	populationTotal->loadPop(total          , var.sequenceName, var.position);
-	populationTarget->loadPop(target        , var.sequenceName, var.position);
-	populationBackground->loadPop(background, var.sequenceName, var.position);
+	populationTotal->loadPop(total          , var.position);
+	populationTarget->loadPop(target        , var.position);
+	populationBackground->loadPop(background, var.position);
 
 	if(populationTarget->npop < 2 || populationBackground->npop < 2){
 	  continue;

--- a/src/plotHaps.cpp
+++ b/src/plotHaps.cpp
@@ -369,7 +369,7 @@ int main(int argc, char** argv) {
 	populationTarget     = makeUnique<gt>();
       }
 
-      populationTarget->loadPop(target, var.sequenceName, var.position);
+      populationTarget->loadPop(target, var.position);
 
       positions.push_back(var.position);
       afs.push_back(populationTarget->af);

--- a/src/popStats.cpp
+++ b/src/popStats.cpp
@@ -250,7 +250,7 @@ int main(int argc, char** argv) {
     populationTarget     = makeUnique<gt>();
 	}
 
-	populationTarget->loadPop(target, var.sequenceName, var.position);
+	populationTarget->loadPop(target, var.position);
 
 	 //cerr << "     3. target allele frequency      "    << endl;
 	 //cerr << "     4. expected heterozygosity      "    << endl;

--- a/src/sequenceDiversity.cpp
+++ b/src/sequenceDiversity.cpp
@@ -448,11 +448,11 @@ int main(int argc, char** argv) {
   populationTotal      = makeUnique<gt>();
       }
 
-      populationTarget->loadPop(target,         var.sequenceName, var.position);
+      populationTarget->loadPop(target,         var.position);
 
-      populationBackground->loadPop(background, var.sequenceName, var.position);
+      populationBackground->loadPop(background, var.position);
 
-      populationTotal->loadPop(total,           var.sequenceName, var.position);
+      populationTotal->loadPop(total,           var.position);
 
       if(populationTotal->af < af_filt){
 	continue;

--- a/src/var.cpp
+++ b/src/var.cpp
@@ -152,7 +152,7 @@ double pl::unphred(map< string, vector<string> > & geno, int index){
    return unphreded;
 }
 
-void pooled::loadPop(vector< map< string, vector<string> > > & group, string seqid, long int position){
+void pooled::loadPop(vector< map< string, vector<string> > > & group, long int position){
   vector< map< string, vector<string> > >::iterator targ_it = group.begin();
 
 
@@ -254,7 +254,7 @@ void pooled::estimatePosterior(void){
   }
 }
 
-void genotype::loadPop( vector< map< string, vector<string> > >& group, string seqid, long int position){
+void genotype::loadPop( vector< map< string, vector<string> > >& group, long int position){
   pos   = position  ;
 
   vector< map< string, vector<string> > >::iterator targ_it = group.begin();

--- a/src/var.cpp
+++ b/src/var.cpp
@@ -255,8 +255,6 @@ void pooled::estimatePosterior(void){
 }
 
 void genotype::loadPop( vector< map< string, vector<string> > >& group, string seqid, long int position){
-
-  seqid = seqid;
   pos   = position  ;
 
   vector< map< string, vector<string> > >::iterator targ_it = group.begin();

--- a/src/var.hpp
+++ b/src/var.hpp
@@ -40,7 +40,7 @@ public:
   double alpha; 
   double beta ;
 
-  virtual void loadPop(vector< map< string, vector<string> > >& group, string seqid, long int position) = 0;
+  virtual void loadPop(vector< map< string, vector<string> > >& group, long int position) = 0;
   virtual void estimatePosterior() = 0 ;
   virtual ~zvar() = 0;
   void setPopName(string  popName);
@@ -64,7 +64,7 @@ public:
   vector< vector < double > > genoLikelihoodsCDF;
 
   virtual double unphred(map< string, vector<string> > & geno, int index) = 0; 
-  virtual void loadPop(vector< map< string, vector<string> > >& group, string seqid, long int position);
+  virtual void loadPop(vector< map< string, vector<string> > >& group, long int position);
   virtual ~genotype() = 0;
   void estimatePosterior();
   
@@ -81,7 +81,7 @@ public:
   vector<double> nrefs;
   vector<double> afs  ; 
 
-  void loadPop(vector< map< string, vector<string> > >& group, string seqid, long int position);
+  void loadPop(vector< map< string, vector<string> > >& group, long int position);
   void estimatePosterior();
 
   ~pooled();

--- a/src/vcfld.cpp
+++ b/src/vcfld.cpp
@@ -412,11 +412,11 @@ int main(int argc, char** argv) {
 	populationTotal      = makeUnique<gp>();
       }
 
-      populationTarget->loadPop(target,         var.sequenceName, var.position);
+      populationTarget->loadPop(target,         var.position);
 
-      populationBackground->loadPop(background, var.sequenceName, var.position);
+      populationBackground->loadPop(background, var.position);
 
-      populationTotal->loadPop(total,           var.sequenceName, var.position);
+      populationTotal->loadPop(total,           var.position);
 
 
       if(populationTotal->af > 0.95 || populationTotal->af < 0.05){

--- a/src/wcFst.cpp
+++ b/src/wcFst.cpp
@@ -268,8 +268,8 @@ int main(int argc, char** argv) {
           populationBackground = makeUnique<gt>();
         }
 
-	populationTarget->loadPop(target, var.sequenceName, var.position);
-	populationBackground->loadPop(background, var.sequenceName, var.position);
+	populationTarget->loadPop(target, var.position);
+	populationBackground->loadPop(background, var.position);
 
 	if(populationTarget->af == -1 || populationBackground->af == -1){
 	  continue;


### PR DESCRIPTION
The variable was only used to make a redundant assignment to itself.
Since it was not a reference but a copy, removing it will also speed up the function call.