### PR TITLE
Variant: pass parameters by const ref.

### DIFF
--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -1658,7 +1658,7 @@ vector<string> VariantCallFile::formatIds(void) {
     return tags;
 }
 
-void VariantCallFile::removeInfoHeaderLine(string tag) {
+void VariantCallFile::removeInfoHeaderLine(string const & tag) {
     vector<string> headerLines = split(header, '\n');
     vector<string> newHeader;
     string id = "ID=" + tag + ",";
@@ -1675,7 +1675,7 @@ void VariantCallFile::removeInfoHeaderLine(string tag) {
     header = join(newHeader, "\n");
 }
 
-void VariantCallFile::removeGenoHeaderLine(string tag) {
+void VariantCallFile::removeGenoHeaderLine(string const & tag) {
     vector<string> headerLines = split(header, '\n');
     vector<string> newHeader;
     string id = "ID=" + tag + ",";

--- a/src/Variant.h
+++ b/src/Variant.h
@@ -97,8 +97,8 @@ public:
     void updateSamples(vector<string>& newSampleNames);
     string headerWithSampleNames(vector<string>& newSamples); // non-destructive, for output
     void addHeaderLine(string line);
-    void removeInfoHeaderLine(string line);
-    void removeGenoHeaderLine(string line);
+    void removeInfoHeaderLine(string const & line);
+    void removeGenoHeaderLine(string const & line);
     vector<string> infoIds(void);
     vector<string> formatIds(void);
 


### PR DESCRIPTION
Passing a parameter by const ref is faster than by value since it avoids calling the copy ctor to instantiate new objects.