### PR TITLE
BiWFA for variant decomposition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,7 +336,7 @@ else()
 endif()
 
 if ((${CMAKE_BUILD_TYPE} MATCHES Release) OR (${CMAKE_BUILD_TYPE} MATCHES RelWithDebInfo))
-  set(wfa_MAKE_ARGS ${wfa_MAKE_ARGS} release)
+  set(wfa_MAKE_ARGS ${wfa_MAKE_ARGS})
 endif()
 
 ExternalProject_Add(wfa-EXT

--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -2150,19 +2150,19 @@ map<string, vector<VariantAllele> > Variant::parsedAlternates(bool includePrevio
        * WFA2-lib
        */
       /*
-      // the C++ WFA2-lib interface is not yet stable due to heuristic initialization issues
+      // the C++ WFA2-lib interface is not yet stable due to heuristic mode initialization issues
       WFAlignerGapAffine2Pieces aligner(19,39,3,81,1,WFAligner::Alignment,WFAligner::MemoryHigh);
       aligner.alignEnd2End(reference_M.c_str(), reference_M.size(), alternateQuery_M.c_str(), alternateQuery_M.size());
       cigar = aligner.getAlignmentCigar();
       */
       auto attributes = wavefront_aligner_attr_default;
-      attributes.memory_mode = wavefront_memory_low;
+      attributes.memory_mode = wavefront_memory_ultralow;
       attributes.distance_metric = gap_affine_2p;
       attributes.affine2p_penalties.match = 0;
-      attributes.affine2p_penalties.mismatch = 4;
-      attributes.affine2p_penalties.gap_opening1 = 6;
-      attributes.affine2p_penalties.gap_extension1 = 2;
-      attributes.affine2p_penalties.gap_opening2 = 26;
+      attributes.affine2p_penalties.mismatch = 19;
+      attributes.affine2p_penalties.gap_opening1 = 39;
+      attributes.affine2p_penalties.gap_extension1 = 3;
+      attributes.affine2p_penalties.gap_opening2 = 81;
       attributes.affine2p_penalties.gap_extension2 = 1;
       attributes.alignment_scope = compute_alignment;
       auto wf_aligner = wavefront_aligner_new(&attributes);

--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -2072,10 +2072,6 @@ string varCigar(vector<VariantAllele>& vav, bool xForMismatch) {
     return cigar;
 }
 
-// parsedAlternates returns a ref and a vector of alts. In this
-// function Smith-Waterman is used with padding on both sides of a ref
-// and each alt. The method and SW are both quadratic in nature.
-
 map<string, vector<VariantAllele> > Variant::parsedAlternates(bool includePreviousBaseForIndels,
                                                               bool useMNPs,
                                                               bool useEntropy,
@@ -2087,6 +2083,41 @@ map<string, vector<VariantAllele> > Variant::parsedAlternates(bool includePrevio
                                                               string flankingRefLeft,
                                                               string flankingRefRight,
                                                               bool useWaveFront,
+                                                              bool debug) {
+
+    auto wfa_params = wavefront_aligner_attr_default;
+    wfa_params.memory_mode = wavefront_memory_ultralow;
+    wfa_params.distance_metric = gap_affine_2p;
+    wfa_params.affine2p_penalties.match = 0;
+    wfa_params.affine2p_penalties.mismatch = 19;
+    wfa_params.affine2p_penalties.gap_opening1 = 39;
+    wfa_params.affine2p_penalties.gap_extension1 = 3;
+    wfa_params.affine2p_penalties.gap_opening2 = 81;
+    wfa_params.affine2p_penalties.gap_extension2 = 1;
+    wfa_params.alignment_scope = compute_alignment;
+
+    return parsedAlternates(includePreviousBaseForIndels,
+                            useMNPs,
+                            useEntropy,
+                            flankingRefLeft,
+                            flankingRefRight,
+                            useWaveFront,
+                            &wfa_params,
+                            debug);
+
+}
+
+// parsedAlternates returns a ref and a vector of alts. In this
+// function Smith-Waterman is used with padding on both sides of a ref
+// and each alt. The method and SW are both quadratic in nature.
+
+map<string, vector<VariantAllele> > Variant::parsedAlternates(bool includePreviousBaseForIndels,
+                                                              bool useMNPs,
+                                                              bool useEntropy,
+                                                              string flankingRefLeft,
+                                                              string flankingRefRight,
+                                                              bool useWaveFront,
+                                                              wavefront_aligner_attr_t* wfaParams,
                                                               bool debug) {
 
   map<string, vector<VariantAllele> > variantAlleles; // return type
@@ -2107,7 +2138,7 @@ map<string, vector<VariantAllele> > Variant::parsedAlternates(bool includePrevio
 
   // padding is used to ensure a stable alignment of the alternates to the reference
   // without having to go back and look at the full reference sequence
-  int paddingLen = (useWaveFront ? 10 : max(10, (int) (ref.size())));  // dynamically determine optimum padding length
+  int paddingLen = 2;
   for (vector<string>::iterator a = alt.begin(); a != alt.end(); ++a) {
     string& alternate = *a;
     paddingLen = max(paddingLen, (int) (alternate.size()));
@@ -2129,6 +2160,14 @@ map<string, vector<VariantAllele> > Variant::parsedAlternates(bool includePrevio
     paddingLen = flankingRefLeft.size();
   }
 
+  for (auto a: alt) { // iterate ALT strings
+    unsigned int referencePos;
+    string& alternate = a;
+    // create the variants slot
+    vector<VariantAllele>& variants = variantAlleles[alternate];
+  }
+
+#pragma omp parallel for 
   for (auto a: alt) { // iterate ALT strings
     unsigned int referencePos;
     string& alternate = a;
@@ -2155,17 +2194,7 @@ map<string, vector<VariantAllele> > Variant::parsedAlternates(bool includePrevio
       aligner.alignEnd2End(reference_M.c_str(), reference_M.size(), alternateQuery_M.c_str(), alternateQuery_M.size());
       cigar = aligner.getAlignmentCigar();
       */
-      auto attributes = wavefront_aligner_attr_default;
-      attributes.memory_mode = wavefront_memory_ultralow;
-      attributes.distance_metric = gap_affine_2p;
-      attributes.affine2p_penalties.match = 0;
-      attributes.affine2p_penalties.mismatch = 19;
-      attributes.affine2p_penalties.gap_opening1 = 39;
-      attributes.affine2p_penalties.gap_extension1 = 3;
-      attributes.affine2p_penalties.gap_opening2 = 81;
-      attributes.affine2p_penalties.gap_extension2 = 1;
-      attributes.alignment_scope = compute_alignment;
-      auto wf_aligner = wavefront_aligner_new(&attributes);
+      auto wf_aligner = wavefront_aligner_new(wfaParams);
       wavefront_aligner_set_heuristic_none(wf_aligner);
       wavefront_aligner_set_alignment_end_to_end(wf_aligner);
       wavefront_align(wf_aligner,
@@ -2195,21 +2224,10 @@ map<string, vector<VariantAllele> > Variant::parsedAlternates(bool includePrevio
                << ">fail.query" << endl
                << alternateQuery_M << endl;
           variantAlleles[alt.front()].push_back(VariantAllele(ref, alt.front(), position));
-          return variantAlleles;
+          exit(1);
+          //return variantAlleles;
       }
       cigarData = splitUnpackedCigar(cigar);
-    }
-    else {
-      CSmithWatermanGotoh sw(matchScore,
-                             mismatchScore,
-                             gapOpenPenalty,
-                             gapExtendPenalty);
-      if (useEntropy) sw.EnableEntropyGapPenalty(1);
-      if (repeatGapExtendPenalty != 0){
-        sw.EnableRepeatGapExtensionPenalty(repeatGapExtendPenalty);
-      }
-      sw.Align(referencePos, cigar, reference_M, alternateQuery_M);
-      cigarData = splitCigar(cigar);
     }
 
     //if (debug)

--- a/src/Variant.h
+++ b/src/Variant.h
@@ -241,6 +241,14 @@ public:
                                                          string flankingRefRight = "",
                                                          bool useWaveFront=true,
                                                          bool debug=false);
+    map<string, vector<VariantAllele> > parsedAlternates(bool includePreviousBaseForIndels,
+                                                         bool useMNPs,
+                                                         bool useEntropy,
+                                                         string flankingRefLeft,
+                                                         string flankingRefRight,
+                                                         bool useWaveFront,
+                                                         wavefront_aligner_attr_t* wfaParams,
+                                                         bool debug);
     // the same output format as parsedAlternates, without parsing
     map<string, vector<VariantAllele> > flatAlternates(void);
 

--- a/src/vcfallelicprimitives.cpp
+++ b/src/vcfallelicprimitives.cpp
@@ -14,6 +14,7 @@ using namespace wfa;
 #include "convert.h"
 #include "join.h"
 #include "split.h"
+#include <omp.h>
 #include <set>
 #include <algorithm>
 #include <getopt.h>
@@ -37,8 +38,8 @@ void printSummary(char** argv) {
          << "Genotypes are handled. Deletion alleles will result in haploid (missing allele) genotypes." << endl
          << endl
          << "options:" << endl
-         << "    -a, --algorithm TYPE    Choose algorithm (default) Wave front or (obsolete) Smith-Waterman" << endl
-         << "                            [WF|SW] algorithm" << endl
+         << "    -p, --wf-params PARAMS  use the given BiWFA params (default: 0,19,39,3,81,1)" << endl
+         << "                            format=match,mismatch,gap1-open,gap1-ext,gap2-open,gap2-ext" << endl
          << "    -m, --use-mnps          Retain MNPs as separate events (default: false)." << endl
          << "    -t, --tag-parsed FLAG   Annotate decomposed records with the source record position" << endl
          << "                            (default: ORIGIN)." << endl
@@ -48,6 +49,7 @@ void printSummary(char** argv) {
          << "                            Note that in many cases, such as multisample VCFs, these won't" << endl
          << "                            be valid post-decomposition.  For biallelic loci in single-sample" << endl
          << "                            VCFs, they should be usable with caution." << endl
+         << "    -j, --threads N         use this many threads for variant decomposition" << endl
          << "    -d, --debug             debug mode." << endl;
     cerr << endl << "Type: transformation" << endl << endl;
     exit(0);
@@ -59,11 +61,13 @@ int main(int argc, char** argv) {
     bool useMNPs = false;
     string parseFlag = "ORIGIN";
     string algorithm = "WF";
+    string paramString = "0,19,39,3,81,1";
     int maxLength = 0;
     bool keepInfo = false;
     bool keepGeno = false;
     bool useWaveFront = true;
     bool debug    = false;
+    int thread_count = 1;
 
     VariantCallFile variantFile;
 
@@ -74,31 +78,26 @@ int main(int argc, char** argv) {
                 /* These options set a flag. */
                 //{"verbose", no_argument,       &verbose_flag, 1},
                 {"help", no_argument, 0, 'h'},
-                {"algorithm", required_argument, 0, 'a'},
+                {"wf-params", required_argument, 0, 'p'},
                 {"use-mnps", no_argument, 0, 'm'},
                 {"max-length", required_argument, 0, 'L'},
                 {"tag-parsed", required_argument, 0, 't'},
                 {"keep-info", no_argument, 0, 'k'},
                 {"keep-geno", no_argument, 0, 'g'},
+                {"threads", required_argument, 0, 'j'},
                 {"debug", no_argument, 0, 'd'},
                 {0, 0, 0, 0}
             };
         /* getopt_long stores the option index here. */
         int option_index = 0;
 
-        c = getopt_long (argc, argv, "dhmkt:L:a:",
+        c = getopt_long (argc, argv, "dhmkt:L:p:j:",
                          long_options, &option_index);
 
         if (c == -1)
             break;
 
         switch (c) {
-
-        case 'a':
-            algorithm = optarg;
-            useWaveFront = (algorithm == "WF");
-            break;
-
 
 	    case 'm':
             useMNPs = true;
@@ -110,6 +109,14 @@ int main(int argc, char** argv) {
 
 	    case 'g':
             keepGeno = true;
+            break;
+
+        case 'p':
+            paramString = optarg;
+            break;
+
+        case 'j':
+            thread_count = atoi(optarg);
             break;
 
 	    case 'd':
@@ -138,6 +145,8 @@ int main(int argc, char** argv) {
         }
     }
 
+    omp_set_num_threads(thread_count);
+
     if (optind < argc) {
         string filename = argv[optind];
         variantFile.open(filename);
@@ -148,6 +157,22 @@ int main(int argc, char** argv) {
     if (!variantFile.is_open()) {
         return 1;
     }
+
+    // parse the alignment parameters
+    vector<string> p_str = split(paramString, ',');
+    vector<int> p;
+    for (auto& s : p_str) { p.push_back(atoi(s.c_str())); }
+
+    auto wfa_params = wavefront_aligner_attr_default;
+    wfa_params.memory_mode = wavefront_memory_ultralow;
+    wfa_params.distance_metric = gap_affine_2p;
+    wfa_params.affine2p_penalties.match = p[0];
+    wfa_params.affine2p_penalties.mismatch = p[1];
+    wfa_params.affine2p_penalties.gap_opening1 = p[2];
+    wfa_params.affine2p_penalties.gap_extension1 = p[3];
+    wfa_params.affine2p_penalties.gap_opening2 = p[4];
+    wfa_params.affine2p_penalties.gap_extension2 = p[5];
+    wfa_params.alignment_scope = compute_alignment;
 
     variantFile.addHeaderLine("##INFO=<ID=TYPE,Number=A,Type=String,Description=\"The type of allele, either snp, mnp, ins, del, or complex.\">");
     variantFile.addHeaderLine("##INFO=<ID=LEN,Number=A,Type=Integer,Description=\"allele length\">");
@@ -191,14 +216,10 @@ int main(int argc, char** argv) {
         map<string, vector<VariantAllele> > varAlleles =
            var.parsedAlternates(includePreviousBaseForIndels, useMNPs,
                                 false, // bool useEntropy = false,
-                                10.0f, // float matchScore = 10.0f,
-                                -9.0f, // float mismatchScore = -9.0f,
-                                15.0f, // float gapOpenPenalty = 15.0f,
-                                6.66f, // float gapExtendPenalty = 6.66f,
-                                0.0f,  // float repeatGapExtendPenalty = 0.0f,
                                 "",    // string flankingRefLeft = "",
                                 "",    // string flankingRefRight = "",
                                 useWaveFront,
+                                &wfa_params,
                                 debug);  // bool debug=false
 
         set<VariantAllele> alleles;


### PR DESCRIPTION
vcfallelicprimitives lets us decompose variant sites into smaller variants.

By using [BiWFA](https://www.biorxiv.org/content/10.1101/2022.04.14.488380v1) we can use O(divergence) space. This lets us decompose sites in parallel. The runtime is as fast as the high-memory (fast) implementation of regular WFA in WFA2-lib.

SWG is disabled forever. vcfallelicprimitives can take WFA parameters on input.

Next up, inversion detection using kmer sketching and possibly score bounding.