### PR TITLE
Fix build without OpenMP: Wrap calls to OMP functionality with #ifdefs

### DIFF
--- a/src/vcfwave.cpp
+++ b/src/vcfwave.cpp
@@ -14,7 +14,9 @@
 #include <vector>
 
 #include <getopt.h>
+#ifdef WFA_PARALLEL
 #include <omp.h>
+#endif
 
 #include "Variant.h"
 #include "vcf-wfa.h"
@@ -181,7 +183,9 @@ int main(int argc, char** argv) {
         }
     }
 
+    #ifdef WFA_PARALLEL
     omp_set_num_threads(thread_count);
+    #endif
 
     off_t file_size = -1;
 


### PR DESCRIPTION
Wrap calls to OMP with #ifdefs so that vcflib is buildable / usable without OMP.

This fixes https://github.com/vcflib/vcflib/issues/380 and helps https://github.com/vcflib/vcflib/issues/350