### PR TITLE
Fix build on newer compilers: Missing #include in rkmh.cpp

### DIFF
--- a/src/rkmh.hpp
+++ b/src/rkmh.hpp
@@ -7,6 +7,7 @@
 #include <unordered_set>
 #include <math.h>
 #include <algorithm>
+#include <limits>
 #include "murmur3.hpp"
 
 // From Eric's https://github.com/edawson/rkmh


### PR DESCRIPTION
Fix missing #include <limits> in rkmh.cpp/hpp, allowing building with newer compilers.

Personally, I really don't like having all of the #includes in the header, but it seems to be what this file is doing, so I'm following the existing format. I'd rather have the .cpp file include the things that it needs, while the .hpp only includes what it needs.

This fixes https://github.com/vcflib/vcflib/issues/382