### PR TITLE
fix build on newer compilers: Replace usage of removed std::random_shuffle

### DIFF
--- a/src/pVst.cpp
+++ b/src/pVst.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <ctime>
 #include <cstdlib>
+#include <random>
 #include "gpatInfo.hpp"
 
 #if defined HAS_OPENMP
@@ -188,7 +189,9 @@ void calc(copyNcounts * d){
 
     trials += 1;
 
-    std::random_shuffle(d->total.begin(), d->total.end());
+    static std::mt19937 g{std::random_device{}()};
+
+    std::shuffle(d->total.begin(), d->total.end(), g);
 
     int tsize = d->target.size();
 


### PR DESCRIPTION
Fix c++17 compatability by removing usage of removed std::random_shuffle and replacing with std::shuffle.

Fixes https://github.com/vcflib/vcflib/issues/379