### PR TITLE
Fix tag-fail long option that was overriden by tag-pass in vcffilter.cpp

### DIFF
--- a/src/vcffilter.cpp
+++ b/src/vcffilter.cpp
@@ -110,7 +110,7 @@ int main(int argc, char** argv) {
                 {"info-filter",  required_argument, 0, 'f'},
                 {"genotype-filter",  required_argument, 0, 'g'},
                 {"tag-pass", required_argument, 0, 't'},
-                {"tag-pass", required_argument, 0, 'F'},
+                {"tag-fail", required_argument, 0, 'F'},
                 {"append-filter", no_argument, 0, 'A'},
                 {"allele-tag", required_argument, 0, 'a'},
                 {"invert", no_argument, 0, 'v'},


### PR DESCRIPTION
Hi!

The long option `--tag-fail` of `vcffilter` was unrecognized, so I fixed the one line needed. The original code incorrectly associated the long option `--tag-pass` with `-F` (in addition to `-t`).