### PR TITLE
use regex to find the '..' between postions and replace it with '-'

### DIFF
--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -13,6 +13,7 @@
 #include "multichoose.h"
 #include <SmithWatermanGotoh.h>
 #include "ssw_cpp.hpp"
+#include <regex>
 
 namespace vcflib {
 
@@ -1509,12 +1510,11 @@ bool VariantCallFile::setRegion(string region) {
         cerr << "cannot setRegion on a non-tabix indexed file" << endl;
         exit(1);
     }
-    size_t dots = region.find("..");
     // convert between bamtools/freebayes style region string and tabix/samtools style
-    if (dots != string::npos) {
-        region.replace(dots, 2, "-");
-    }
-    if (tabixFile->setRegion(region)) {
+    regex txt_regex("(\\d+)\\.\\.(\\d+)$");
+    string tabix_region = regex_replace(region, txt_regex, "$1-$2");
+
+    if (tabixFile->setRegion(tabix_region)) {
         if (tabixFile->getNextLine(line)) {
 	    justSetRegion = true;
             return true;


### PR DESCRIPTION
the bamtools/freebayes style region string can be something like: "chrXII:456088..465424:1111..3333".  We cannot replace all ".." to '-" in the region string.  