### PR TITLE
Fix vcfwave.cpp

### DIFF
--- a/src/vcfwave.cpp
+++ b/src/vcfwave.cpp
@@ -3,6 +3,7 @@
 
     Copyright © 2010-2024 Erik Garrison
     Copyright © 2020-2024 Pjotr Prins
+    Copyright © 2024 Andrea Guarracino
 
     This software is published under the MIT License. See the LICENSE file.
 */
@@ -302,7 +303,7 @@ int main(int argc, char** argv) {
                     string AT;
                     double AF = -1;
                     string wftag = alt0+":"+to_string(wfpos)+":"+ref+"/"+aligned;
-                    if (var.ref != aligned) {
+                    if (ref != aligned) {
                         auto index = [&](vector<string> v, string allele) {
                             //auto check = (is_inv ? reverse_complement(allele) : allele); DISABLED
                             auto check = allele;


### PR DESCRIPTION
When decomposing this variant

```
SGDref#0#chrI	92298	>6309685>6309691	TTG	TGT,TTT,TTTGG	60	.	AC=2,1,1;AF=0.111111,0.0555556,0.0555556;AN=18;AT=>6309685>6309687>6309690>6309691,>6309685>6309686>6309689>6309691,>6309685>6309687>6309689>6309691,>6309685>6309687>6309688>6309690>6309691;NS=14;LV=0	GT	0	0|0	0	0|0	0	0|0	1	0|0	0	1	2	0	3	0
```

We were getting

```
SGDref#0#chrI	92299	>6309685>6309691_1	T	TTG	60	.	AC=2,1,1;AF=0.111111,0.0555556,0.0555556;AN=18;AT=>6309685>6309687>6309690>6309691,>6309685>6309686>6309689>6309691,>6309685>6309687>6309689>6309691,>6309685>6309687>6309688>6309690>6309691;NS=14;LV=0;ORIGIN=SGDref#0#chrI:92298;LEN=2	GT	0	0|0	0	0|0	0	0|0	0	0|0	0	0	0	0	1	0
SGDref#0#chrI	92299	>6309685>6309691_2	TG	GT	60	.	AC=2;AF=0.111111;AN=18;AT=>6309685>6309687>6309690>6309691;NS=14;LV=0;ORIGIN=SGDref#0#chrI:92298;LEN=2	GT	0	0|0	0	0|0	0	0|0	1	0|0	0	1	0	0	0	0
SGDref#0#chrI	92300	>6309685>6309691_3	G	T	60	.	AC=1;AF=0.055556;AN=18;AT=>6309685>6309686>6309689>6309691;NS=14;LV=0;ORIGIN=SGDref#0#chrI:92298;LEN=1	GT	0	0|0	0	0|0	0	0|0	0	0|0	0	0	1	0	0	0
```

where the first variant has wrong AC, AF, and AT fields (3 values each instead of just 1).

The fix avoids that and now we get

```
SGDref#0#chrI  92299  >6309685>6309691_1  T   TTG  60  .  AC=1;AF=0.055556;AN=18;AT=>6309685>6309687>6309689>6309691;NS=14;LV=0;ORIGIN=SGDref#0#chrI:92298;LEN=2;TYPE=ins  GT  0  0|0  0  0|0  0  0|0  0  0|0  0  0  0  0  1  0
SGDref#0#chrI  92299  >6309685>6309691_2  TG  GT   60  .  AC=2;AF=0.111111;AN=18;AT=>6309685>6309687>6309690>6309691;NS=14;LV=0;ORIGIN=SGDref#0#chrI:92298;LEN=2;TYPE=mnp  GT  0  0|0  0  0|0  0  0|0  1  0|0  0  1  0  0  0  0
SGDref#0#chrI  92300  >6309685>6309691_3  G   T    60  .  AC=1;AF=0.055556;AN=18;AT=>6309685>6309686>6309689>6309691;NS=14;LV=0;ORIGIN=SGDref#0#chrI:92298;LEN=1;TYPE=snp  GT  0  0|0  0  0|0  0  0|0  0  0|0  0  0  1  0  0  0
```