### PR TITLE
Use find_path to set WFA_INCLUDE_DIRS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,8 +381,7 @@ if(WFA_GITMODULE)
   add_subdirectory(${WFA_LOCAL})
   set(WFALIB wfa2) # pick up the wfa2 lib target from the included CMakeLists.txt
 else(WFA_GITMODULE)
-  include_directories($ENV{CMAKE_PREFIX_PATH}/include/wfa2lib)
-  set(WFA_INCLUDE_DIRS ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}/wfa2lib)
+  find_path(WFA_INCLUDE_DIRS wavefront/wfa.hpp PATH_SUFFIXES wfa2lib)
   find_library(WFALIB wfa2 wfa REQUIRED) # distro search for shared lib
 endif(WFA_GITMODULE)
 


### PR DESCRIPTION
Previous logic had some issues:
* `CMAKE_PREFIX_PATH` may be a list of paths
* `CMAKE_INSTALL_PREFIX` can be different from WFA2-lib path

find_path will search every path in `CMAKE_PREFIX_PATH` along with some other locations like `CMAKE_INCLUDE_PATH` and `CMAKE_INSTALL_PREFIX`. Also user can override detection using variables.
