### PR TITLE
Enable shared libraries via `-DBUILD_SHARED_LIBS=ON`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,7 @@ if (TABIXPP_LOCAL) # add the tabixpp source file
     list(APPEND vcflib_SOURCE ${tabixpp_SOURCE})
 endif()
 
-add_library(vcflib STATIC
+add_library(vcflib
     ${vcflib_SOURCE}
     )
 
@@ -453,6 +453,9 @@ add_dependencies(vcflib ${vcflib_DEPS})
 
 # ---- Build all
 
+if (BUILD_SHARED_LIBS)
+  target_link_libraries(vcflib PUBLIC ${vcflib_LIBS} ${WFALIB})
+endif()
 if (NOT BUILD_ONLY_LIB)
   foreach(BIN ${BINS})
     add_executable(${BIN} src/${BIN}.cpp)


### PR DESCRIPTION
This simplifies packaging in most repositories/distros that require shared libraries.

---

Default behavior should remain the same.

Shared libraries can be enabled by setting cache variable: `cmake -DBUILD_SHARED_LIBS=ON`