### PR TITLE
Fixed CI

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -5,11 +5,22 @@ jobs:
     name: vcflib-CI
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+          include:
+              - os: ubuntu-22.04
+                python-version: "3.8"
+              - os: ubuntu-24.04
+                python-version: "3.9"
+              - os: ubuntu-24.04
+                python-version: "3.10"
+              - os: ubuntu-24.04
+                python-version: "3.11"
+              - os: ubuntu-24.04
+                python-version: "3.12"
+
     steps:
     - name: apt update
       run: sudo apt-get -o Acquire::Retries=3 update
@@ -20,7 +31,9 @@ jobs:
         libtabixpp-dev
         libtabixpp0
         pybind11-dev
-        libbz2-dev # needed for ubuntu 24.04
+    - name: install libbz2-dev for 24.04
+      if: matrix.os == 'ubuntu-24.04'
+      run: sudo apt-get -o Acquire::Retries=3 install -y -Vlibbz2-dev # needed for ubuntu 24.04
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v1
       with:

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -3,10 +3,7 @@ on: [push, pull_request]
 jobs:
   arch:
     name: vcflib-CI
-    env:
-      ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
-    runs-on: ${{ matrix.os }}
-
+    
     strategy:
       matrix:
           include:
@@ -20,6 +17,9 @@ jobs:
                 python-version: "3.11"
               - os: ubuntu-24.04
                 python-version: "3.12"
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+    runs-on: ${{ matrix.os }}
 
     steps:
     - name: apt update

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -10,16 +10,8 @@ jobs:
     strategy:
         matrix:
             include:
-                 - os: ubuntu-22.04
+                 - os: ubuntu-20.04
                    python-version: "3.8"
-                 - os: ubuntu-22.04
-                   python-version: "3.9"
-                 - os: ubuntu-22.04
-                   python-version: "3.10"
-                 - os: ubuntu-22.04
-                   python-version: "3.11"
-                 - os: ubuntu-22.04
-                   python-version: "3.12"
     steps:
     - name: apt update
       run: sudo apt-get -o Acquire::Retries=3 update

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -5,13 +5,11 @@ jobs:
     name: vcflib-CI
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     strategy:
-        matrix:
-            include:
-                 - os: ubuntu-22.04
-                   python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - name: apt update
       run: sudo apt-get -o Acquire::Retries=3 update

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -20,6 +20,7 @@ jobs:
         libtabixpp-dev
         libtabixpp0
         pybind11-dev
+        libbz2-dev # needed for ubuntu 24.04
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v1
       with:

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -5,7 +5,7 @@ jobs:
     name: vcflib-CI
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
         matrix:

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -33,7 +33,7 @@ jobs:
         pybind11-dev
     - name: install libbz2-dev for 24.04
       if: matrix.os == 'ubuntu-24.04'
-      run: sudo apt-get -o Acquire::Retries=3 install -y -Vlibbz2-dev # needed for ubuntu 24.04
+      run: sudo apt-get -o Acquire::Retries=3 install -y -V libbz2-dev # needed for ubuntu 24.04
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v1
       with:

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
         matrix:
             include:
-                 - os: ubuntu-20.04
+                 - os: ubuntu-22.04
                    python-version: "3.8"
     steps:
     - name: apt update

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -11,15 +11,15 @@ jobs:
         matrix:
             include:
                  - os: ubuntu-20.04
-                   python-version: 3.8
+                   python-version: "3.8"
                  - os: ubuntu-latest
-                   python-version: 3.9
+                   python-version: "3.9"
                  - os: ubuntu-latest
-                   python-version: 3.10
+                   python-version: "3.10"
                  - os: ubuntu-latest
-                   python-version: 3.11
+                   python-version: "3.11"
                  - os: ubuntu-latest
-                   python-version: 3.12
+                   python-version: "3.12"
     steps:
     - name: apt update
       run: sudo apt-get -o Acquire::Retries=3 update

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -10,15 +10,15 @@ jobs:
     strategy:
         matrix:
             include:
-                 - os: ubuntu-20.04
+                 - os: ubuntu-22.04
                    python-version: "3.8"
-                 - os: ubuntu-latest
+                 - os: ubuntu-22.04
                    python-version: "3.9"
-                 - os: ubuntu-latest
+                 - os: ubuntu-22.04
                    python-version: "3.10"
-                 - os: ubuntu-latest
+                 - os: ubuntu-22.04
                    python-version: "3.11"
-                 - os: ubuntu-latest
+                 - os: ubuntu-22.04
                    python-version: "3.12"
     steps:
     - name: apt update

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -11,7 +11,7 @@ jobs:
         matrix:
             include:
                  - os: ubuntu-22.04
-                   python-version: "3.8"
+                   python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - name: apt update
       run: sudo apt-get -o Acquire::Retries=3 update

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -8,9 +8,18 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: [3.8]
+        matrix:
+            include:
+                 - os: ubuntu-20.04
+                   python-version: 3.8
+                 - os: ubuntu-latest
+                   python-version: 3.9
+                 - os: ubuntu-latest
+                   python-version: 3.10
+                 - os: ubuntu-latest
+                   python-version: 3.11
+                 - os: ubuntu-latest
+                   python-version: 3.12
     steps:
     - name: apt update
       run: sudo apt-get -o Acquire::Retries=3 update


### PR DESCRIPTION
CI was broken as GitHub moved to ubuntu-24.04 for `ubuntu-latest`, and it doesn't have python 3.8 version that we requested to test. 

* Added Ubuntu 22.04 explicitly with python 3.8
* Added Ubuntu 24.04, had to add `install libbz2-dev` to make it work
* Added more python versions, all work well