### PR TITLE
Adding CSI index support with raw htslib function calls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,9 @@ find_package(BZip2 REQUIRED)   # htslib
 find_package(LibLZMA REQUIRED) # htslib
 find_package(PkgConfig REQUIRED)
 find_package(ZLIB REQUIRED)
+
+set(PYBIND11_FINDPYTHON ON)
+find_package(Python COMPONENTS Interpreter Development REQUIRED)
 find_package(pybind11 CONFIG)
 
 include(GNUInstallDirs)
@@ -64,7 +67,7 @@ find_package(Threads)
 set_package_properties(Threads PROPERTIES TYPE REQUIRED)
 
 pkg_check_modules(htslib IMPORTED_TARGET htslib)   # Optionally builds from contrib/
-pkg_check_modules(tabixpp IMPORTED_TARGET tabixpp) # Optionally builds from contrib/
+pkg_check_modules(libdeflate IMPORTED_TARGET libdeflate)
 
 # ---- Build switches
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ${ipo_supported})
@@ -123,17 +126,9 @@ if(NOT htslib_FOUND)
   message(STATUS "Using included htslib")
   include(FindCURL) # for htslib
   set(htslib_LOCAL contrib/tabixpp/htslib)
-  set(tabixpp_FOUND OFF) # also build tabixpp if htslib is missing
 endif()
 
-if(NOT tabixpp_FOUND)
-  message(STATUS "Using included tabixpp")
-  set(tabixpp_LOCAL contrib/tabixpp)
-  include_directories(contrib/tabixpp)
-  set(tabixpp_SOURCE
-    contrib/tabixpp/tabix.cpp
-  )
-endif()
+
 
 if(WFA_GITMODULE)
   set(WFA_LOCAL contrib/WFA2-lib)
@@ -181,10 +176,7 @@ set(vcflib_SOURCE
     contrib/c-progress-bar/progress.c
 )
 
-if (tabixpp_LOCAL) # add the tabixpp source file
-    list(APPEND vcflib_SOURCE ${tabixpp_SOURCE})
-    list(APPEND INCLUDES ${tabixpp_LOCAL}/tabix.hpp)
-endif()
+
 
 add_library(vcflib
     ${vcflib_SOURCE}
@@ -412,28 +404,28 @@ else (ZIG)
   add_definitions(-DNO_ZIG=1)
 endif (ZIG)
 
-if (htslib_LOCAL)
-  target_link_libraries(vcflib htslib)
-  set(vcflib_LIBS curl deflate) # local build requires linking curl explicitly
-else ()
-  target_link_libraries(vcflib PkgConfig::htslib)
-  set(vcflib_LIBS hts)
-endif()
-
 list(APPEND htslib_dependencies
   lzma
   z
   bz2
 )
 
-list(APPEND vcflib_LIBS
-  ${CMAKE_THREAD_LIBS_INIT}
-  ${htslib_dependencies} # linking htslib for everything is not needed if we have our own bgzip reader
-)
-
-if (NOT tabixpp_LOCAL)
-  target_link_libraries(vcflib PkgConfig::tabixpp)
+if (htslib_LOCAL)
+  # When using local htslib, link all its dependencies directly to vcflib
+  if (libdeflate_FOUND)
+    target_link_libraries(vcflib htslib ${htslib_dependencies} ${CURL_LIBRARIES} PkgConfig::libdeflate)
+  else()
+    target_link_libraries(vcflib htslib ${htslib_dependencies} ${CURL_LIBRARIES})
+  endif()
+else ()
+  target_link_libraries(vcflib PkgConfig::htslib)
 endif()
+
+# vcflib_LIBS is used for binaries that link against vcflib
+# No need to add htslib_dependencies again since they're already linked into vcflib
+set(vcflib_LIBS ${CMAKE_THREAD_LIBS_INIT})
+
+
 
 if(OPENMP)
   target_link_libraries(vcflib OpenMP::OpenMP_CXX)
@@ -470,7 +462,7 @@ if (NOT BUILD_ONLY_LIB)
 endif()
 
 
-if (NOT BUILD_STATIC) # only when not building static
+if (NOT BUILD_STATIC AND pybind11_FOUND) # only when not building static and pybind11 is available
   # ---- Python bindings - mostly for testing at this stage
   pybind11_add_module(pyvcflib "${CMAKE_SOURCE_DIR}/src/pythonffi.cpp")
   # add_dependencies(pyvcflib CURL::libcurl)
@@ -527,18 +519,20 @@ endfunction()
   add_zigtest()
 endif(ZIG_TEST)
 
-add_pytest(realign)
-add_pydoctest(pyvcflib)
-add_pydoctest(vcflib-api)
-add_pydoctest(vcf2tsv)
-add_pydoctest(vcfallelicprimitives)
-add_pydoctest(vcfwave)
-add_pydoctest(vcffilter)
-if (ZIG)
-  add_pydoctest(vcfcreatemulti)
-endif (ZIG)
+if (pybind11_FOUND)
+  add_pytest(realign)
+  add_pydoctest(pyvcflib)
+  add_pydoctest(vcflib-api)
+  add_pydoctest(vcf2tsv)
+  add_pydoctest(vcfallelicprimitives)
+  add_pydoctest(vcfwave)
+  add_pydoctest(vcffilter)
+  if (ZIG)
+    add_pydoctest(vcfcreatemulti)
+  endif (ZIG)
 
-add_pydoctest(vcfnulldotslashdot)
+  add_pydoctest(vcfnulldotslashdot)
+endif()
 add_doctest(doc/vcfintersect)
 
 # ---- Build documentation

--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -1627,6 +1627,26 @@ bool VariantCallFile::openVCF(ifstream& stream) {
 }
 */
 
+bool VariantCallFile::openTabix(const string& filename) {
+    // Open compressed file
+    htsFp = hts_open(filename.c_str(), "r");
+    if (!htsFp) {
+        throw std::runtime_error("Failed to open indexed VCF file: " + filename);
+    }
+    
+    // Load index (.tbi or .csi - htslib tries both automatically)
+    tbxIdx = tbx_index_load(filename.c_str());
+    if (!tbxIdx) {
+        hts_close(htsFp);
+        htsFp = NULL;
+        throw std::runtime_error("Failed to load index for file: " + filename);
+    }
+    
+    usingTabix = true;
+    parsedHeader = parseHeader();
+    return parsedHeader;
+}
+
 void VariantCallFile::updateSamples(vector<string>& newSamples) {
     sampleNames = newSamples;
     // regenerate the last line of the header
@@ -1749,17 +1769,29 @@ void VariantCallFile::removeGenoHeaderLine(string const & tag) {
     header = join(newHeader, "\n");
 }
 
+off_t VariantCallFile::file_pos(void) {
+    if (usingTabix && htsFp) {
+        return bgzf_tell(htsFp->fp.bgzf);
+    }
+    return file->tellg();
+}
+
 vector<string> VariantCallFile::getHeaderLinesFromFile()
 {
     string headerStr = "";
 
     if (usingTabix) {
-        tabixFile->getHeader(headerStr);
-        if (headerStr.empty()) {
-            cerr << "error: no VCF header" << endl;
-            exit(1);
+        // Read header lines (those starting with meta_char, typically '#')
+        while (hts_getline(htsFp, KS_SEP_LINE, &tbxStr) >= 0) {
+            if (!tbxStr.l || tbxStr.s[0] != tbxIdx->conf.meta_char) {
+                line = string(tbxStr.s);
+                break;  // Stop at first non-header line
+            }
+            headerStr += string(tbxStr.s) + "\n";
         }
-        tabixFile->getNextLine(line);
+        if (headerStr.empty()) {
+            throw std::runtime_error("error: no VCF header");
+        }
         firstRecord = true;
     } else {
         while (std::getline(*file, line)) {
@@ -1784,12 +1816,17 @@ bool VariantCallFile::parseHeader(void) {
     string headerStr = "";
 
     if (usingTabix) {
-        tabixFile->getHeader(headerStr);
-        if (headerStr.empty()) {
-            cerr << "error: no VCF header" << endl;
-            exit(1);
+        // Read header lines (those starting with meta_char, typically '#')
+        while (hts_getline(htsFp, KS_SEP_LINE, &tbxStr) >= 0) {
+            if (!tbxStr.l || tbxStr.s[0] != tbxIdx->conf.meta_char) {
+                line = string(tbxStr.s);
+                break;  // Stop at first non-header line
+            }
+            headerStr += string(tbxStr.s) + "\n";
         }
-        tabixFile->getNextLine(line);
+        if (headerStr.empty()) {
+            throw std::runtime_error("error: no VCF header");
+        }
         firstRecord = true;
     } else {
         while (std::getline(*file, line)) {
@@ -1924,13 +1961,28 @@ bool VariantCallFile::getNextVariant(Variant& var) {
                 justSetRegion = false;
                 _done = false;
                 return true;
-            } else if (tabixFile->getNextLine(line)) {
-                var.parse(line, parseSamples);
-                _done = false;
-                return true;
             } else {
-                _done = true;
-                return false;
+                int ret;
+                if (tbxIter) {
+                    // Reading with region filter
+                    ret = tbx_itr_next(htsFp, tbxIdx, tbxIter, &tbxStr);
+                } else {
+                    // Sequential reading without region
+                    ret = hts_getline(htsFp, KS_SEP_LINE, &tbxStr);
+                    // Skip header lines if any
+                    while (ret >= 0 && tbxStr.l && tbxStr.s[0] == tbxIdx->conf.meta_char) {
+                        ret = hts_getline(htsFp, KS_SEP_LINE, &tbxStr);
+                    }
+                }
+                if (ret >= 0) {
+                    line = string(tbxStr.s);
+                    var.parse(line, parseSamples);
+                    _done = false;
+                    return true;
+                } else {
+                    _done = true;
+                    return false;
+                }
             }
         } else {
             if (std::getline(*file, line)) {
@@ -1956,21 +2008,32 @@ bool VariantCallFile::setRegion(const string& seq, long int start, long int end)
 
 bool VariantCallFile::setRegion(const string& region) {
     if (!usingTabix) {
-        cerr << "cannot setRegion on a non-tabix indexed file" << endl;
-        exit(1);
+        throw std::runtime_error("cannot setRegion on a non-tabix indexed file");
     }
     // convert between bamtools/freebayes style region string and tabix/samtools style
     regex txt_regex("(\\d+)\\.\\.(\\d+)$");
     string tabix_region = regex_replace(region, txt_regex, "$1-$2");
 
-    if (tabixFile->setRegion(tabix_region)) {
-        if (tabixFile->getNextLine(line)) {
-	    justSetRegion = true;
-            return true;
-        } else {
-            return false;
-        }
+    // Clean up existing iterator if any
+    if (tbxIter) {
+        tbx_itr_destroy(tbxIter);
+        tbxIter = NULL;
+    }
+    
+    // Create new iterator for region
+    tbxIter = tbx_itr_querys(tbxIdx, tabix_region.c_str());
+    if (!tbxIter) {
+        return false;  // Invalid region
+    }
+    
+    // Try to read first line in region
+    if (tbx_itr_next(htsFp, tbxIdx, tbxIter, &tbxStr) >= 0) {
+        line = string(tbxStr.s);
+        justSetRegion = true;
+        return true;
     } else {
+        tbx_itr_destroy(tbxIter);
+        tbxIter = NULL;
         return false;
     }
 }

--- a/src/Variant.h
+++ b/src/Variant.h
@@ -24,7 +24,10 @@
 #include <queue>
 #include <set>
 #include "split.h"
-#include <tabix.hpp>
+#include <htslib/hts.h>
+#include <htslib/tbx.h>
+#include <htslib/bgzf.h>
+#include <htslib/kseq.h>
 #include <Fasta.h>
 
 #include "allele.hpp"
@@ -75,7 +78,10 @@ class VariantCallFile {
 public:
 
     istream* file;
-    Tabix* tabixFile;
+    htsFile* htsFp;        // htslib file handle for indexed files
+    tbx_t* tbxIdx;         // tabix/csi index structure
+    hts_itr_t* tbxIter;    // iterator for region queries
+    kstring_t tbxStr;      // string buffer for reading lines
 
     bool usingTabix;
     string vcf_header;
@@ -120,13 +126,7 @@ public:
         return parsedHeader;
     }
 
-    bool openTabix(const string& filename) {
-        usingTabix = true;
-        // Tabix does not modify the string, better to keep rest of the interface clean
-        tabixFile = new Tabix(const_cast<string&>(filename));
-        parsedHeader = parseHeader();
-        return parsedHeader;
-    }
+    bool openTabix(const string& filename);
 
     bool open(istream& stream) {
         file = &stream;
@@ -145,23 +145,36 @@ public:
         return parsedHeader;
     }
 
-    off_t file_pos() {
-        if (usingTabix) {
-            return tabixFile->file_pos();
-        }
-        return file->tellg();
-    }
+    off_t file_pos();
 
     VariantCallFile(void) :
+        htsFp(NULL),
+        tbxIdx(NULL),
+        tbxIter(NULL),
         usingTabix(false),
         parseSamples(true),
         justSetRegion(false),
         parsedHeader(false)
-    { }
+    {
+        tbxStr.l = 0;
+        tbxStr.m = 0;
+        tbxStr.s = NULL;
+    }
 
     ~VariantCallFile(void) {
         if (usingTabix) {
-            delete tabixFile;
+            if (tbxIter) {
+                tbx_itr_destroy(tbxIter);
+            }
+            if (tbxIdx) {
+                tbx_destroy(tbxIdx);
+            }
+            if (tbxStr.s) {
+                free(tbxStr.s);
+            }
+            if (htsFp) {
+                hts_close(htsFp);
+            }
         }
     }
 


### PR DESCRIPTION
Claude seemed pretty happy to refactor the tabix loading code to use more raw htslib functions which natively support .tbi or .csi style indexes. This drops tabixpp as a dependency since all the necessary code was already in htslib. Some pybind and various library linking changes were necessary to get this to build nicely on my x86 mac, but then some of the `ctest` tests fail.

However, I tried some of the different `vcf*` commands on a file indexed with .csi and it worked, while using the conda version of the same commands failed. Both worked and gave identical output on .tbi indexes.

Since the *variant.h* file is used in many other projects, probably needs a lot more care in checking this works as intended.