### PR TITLE
cmake: support tabixpp without pkgconfig file

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -7,13 +7,13 @@ jobs:
       matrix:
           include:
               - os: ubuntu-24.04
-                python-version: "3.9"
-              - os: ubuntu-24.04
                 python-version: "3.10"
               - os: ubuntu-24.04
                 python-version: "3.11"
               - os: ubuntu-24.04
                 python-version: "3.12"
+              - os: ubuntu-24.04
+                python-version: "3.13"
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
     runs-on: ${{ matrix.os }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ pkg_check_modules(tabixpp IMPORTED_TARGET tabixpp) # Optionally builds from cont
 if(tabixpp_FOUND)
   set(TABIXPP_LIB PkgConfig::tabixpp)
 else()
-  find_path(TABIXPP_INCLUDE_DIR tabix.hpp)
+  find_path(TABIXPP_INCLUDE_DIR tabix.hpp PATH_SUFFIXES tabix)
   find_library(TABIXPP_LIB NAMES tabixpp tabix)
   if(TABIXPP_INCLUDE_DIR AND TABIXPP_LIB)
     include_directories(${TABIXPP_INCLUDE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,16 @@ set_package_properties(Threads PROPERTIES TYPE REQUIRED)
 
 pkg_check_modules(htslib IMPORTED_TARGET htslib)   # Optionally builds from contrib/
 pkg_check_modules(tabixpp IMPORTED_TARGET tabixpp) # Optionally builds from contrib/
+if(tabixpp_FOUND)
+  set(TABIXPP_LIB PkgConfig::tabixpp)
+else()
+  find_path(TABIXPP_INCLUDE_DIR tabix.hpp)
+  find_library(TABIXPP_LIB NAMES tabixpp tabix)
+  if(TABIXPP_INCLUDE_DIR AND TABIXPP_LIB)
+    include_directories(${TABIXPP_INCLUDE_DIR})
+    set(tabixpp_FOUND ON)
+  endif()
+endif()
 
 # ---- Build switches
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ${ipo_supported})
@@ -432,7 +442,7 @@ list(APPEND vcflib_LIBS
 )
 
 if (NOT tabixpp_LOCAL)
-  target_link_libraries(vcflib PkgConfig::tabixpp)
+  target_link_libraries(vcflib ${TABIXPP_LIB})
 endif()
 
 if(OPENMP)


### PR DESCRIPTION
Allow using system `tabixpp` outside of GNU Guix.

May be worth adding pkg-config file to https://github.com/vcflib/tabixpp, but in mean time could just find the headers/libraries manually.

Was mainly looking at this for Homebrew, but change may help detect system installed copy from:
- Debian (libtabixpp.so) - https://packages.debian.org/forky/libtabixpp-dev
- FreeBSD (libtabix.so) - https://github.com/freebsd/freebsd-ports/blob/main/biology/tabixpp/Makefile
- BioArch (tabix/tabix.hpp) - https://github.com/BioArchLinux/Packages/blob/master/BioArchLinux/tabixpp/PKGBUILD

---

EDIT: CI logs confirm this works on Ubuntu.

Last run prior to this PR is https://github.com/vcflib/vcflib/actions/runs/18965062806
```
-- Checking for module 'tabixpp'
--   Package 'tabixpp', required by 'virtual:world', not found
-- Using included tabixpp
-- Using included libwfa
```

This PR run:
```
-- Checking for module 'tabixpp'
--   Package 'tabixpp', required by 'virtual:world', not found
-- Using included libwfa
```
```
/usr/bin/c++ -fPIC -O2 -g -DNDEBUG -flto=auto ... /usr/lib/x86_64-linux-gnu/libhts.so /usr/lib/x86_64-linux-gnu/libtabixpp.so /usr/lib/gcc/x86_64-linux-gnu/13/libgomp.so /usr/lib/x86_64-linux-gnu/libpthread.a
```